### PR TITLE
CAUSEWAY-3348: Parameters as Tuple Support (PAT)

### DIFF
--- a/api/applib/src/main/java/org/apache/causeway/applib/annotation/ParameterAsTuple.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/annotation/ParameterAsTuple.java
@@ -46,5 +46,5 @@ import java.lang.annotation.Target;
         ElementType.ANNOTATION_TYPE
 })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ParameterTuple {
+public @interface ParameterAsTuple {
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/annotation/ParameterTuple.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/annotation/ParameterTuple.java
@@ -1,0 +1,50 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.applib.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a mixed-in action's parameter follows the parameters-as-tuple (PAT) semantics.
+ * <p>
+ * Example mixin code:
+ * <pre>
+ * // java record as a parameters tuple
+ * record Params(@Parameter String key, &#64;Parameter String name) {}
+ *
+ * // mixin's main method using the tuple type
+ * &#64;MemberSupport public Result act(&#64;ParameterTuple Params p) { ... }
+ * </pre>
+ *
+ * @apiNote Java record support will not come before version 3.0
+ *
+ * @since 2.0 {@index}
+ */
+@Inherited
+@Target({
+        ElementType.PARAMETER,
+        ElementType.ANNOTATION_TYPE
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ParameterTuple {
+}

--- a/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
+++ b/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
@@ -19,6 +19,7 @@
 package org.apache.causeway.commons.internal.reflection;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.util.Optional;
@@ -26,6 +27,8 @@ import java.util.Optional;
 import org.apache.causeway.commons.internal.base._NullSafe;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 
+import lombok.NonNull;
+import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -40,14 +43,28 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class _MethodFacades {
 
+    @Deprecated
     public MethodFacade autodetect(final Method method) {
         return method.getParameterCount()!=0
                 ? new RegularMethod(method) //FIXME check if Parameters-as-Tuple semantics applies
                 : new RegularMethod(method);
     }
-    //eg. for simple JUnit testing
+
+    public static MethodFacade paramsAsTuple(final @NonNull Method method, final @NonNull Constructor<?> patConstructor) {
+        return new ParamsAsTupleMethod(patConstructor, regularMethodForSyntheticElseFail(method));
+    }
+
+    /**
+     * use with care:
+     * <ul>
+     * <li>property accessors</li>
+     * <li>collections accessors</li>
+     * <li>support methods</li>
+     * <li>JUnit testing</li>
+     * </ul>
+     */
     public static MethodFacade regular(final Method method) {
-        return new RegularMethod(method);
+        return new RegularMethod(regularMethodForSyntheticElseFail(method));
     }
 
     public static interface MethodFacade {
@@ -74,7 +91,7 @@ public class _MethodFacades {
 
         /**
          * This is a convenience method for scenarios where a Method or Constructor reference is treated in a generic fashion.
-         * eg. to process parameter annotations.
+         * Used to introspect parameter annotations.
          */
         Executable asExecutable();
 
@@ -94,84 +111,127 @@ public class _MethodFacades {
         boolean isAnnotatedAsNullable();
     }
 
+    /**
+     * Wraps a {@link Method}, implemented as a transparent pass through.
+     */
     @lombok.Value
     private final static class RegularMethod implements MethodFacade {
 
         private final Method method;
 
-        @Override
-        public Class<?> getDeclaringClass() {
+        @Override public Class<?> getDeclaringClass() {
             return method.getDeclaringClass();
         }
-
-        @Override
-        public int getParameterCount() {
+        @Override public int getParameterCount() {
             return method.getParameterCount();
         }
-
-        @Override
-        public Class<?>[] getParameterTypes() {
+        @Override public Class<?>[] getParameterTypes() {
             return method.getParameterTypes();
         }
-
-        @Override
-        public Class<?> getParameterType(final int paramNum) {
+        @Override public Class<?> getParameterType(final int paramNum) {
             return method.getParameterTypes()[paramNum];
         }
-
-        @Override
-        public String getName() {
+        @Override public String getName() {
             return method.getName();
         }
-
-        @Override
-        public Class<?> getReturnType() {
+        @Override public Class<?> getReturnType() {
             return method.getReturnType();
         }
-
-        @Override
-        public Optional<Method> asMethod() {
+        @Override public Optional<Method> asMethod() {
             return Optional.of(method);
         }
-
-        @Override
-        public Executable asExecutable() {
+        @Override public Executable asExecutable() {
             return method;
         }
-
-        @Override
-        public <A extends Annotation> Optional<A> synthesize(final Class<A> annotationType) {
+        @Override public <A extends Annotation> Optional<A> synthesize(final Class<A> annotationType) {
             return _Annotations.synthesize(method, annotationType);
         }
-
-        @Override
-        public Method asMethodForIntrospection() {
+        @Override public Method asMethodForIntrospection() {
             return method;
         }
-
-        @Override
-        public String getParameterName(final int paramNum) {
+        @Override public String getParameterName(final int paramNum) {
             return method.getParameters()[paramNum].getName();
         }
-
-        @Override
-        public <A extends Annotation> Optional<A> synthesizeOnParameter(final Class<A> annotationType, final int paramNum) {
+        @Override public <A extends Annotation> Optional<A> synthesizeOnParameter(final Class<A> annotationType, final int paramNum) {
             return _Annotations.synthesize(method.getParameters()[paramNum], annotationType);
         }
-
-        @Override
-        public Object[] getArguments(final Object[] executionParameters) {
+        @Override public Object[] getArguments(final Object[] executionParameters) {
             return executionParameters;
         }
-
-        @Override
-        public boolean isAnnotatedAsNullable() {
+        @Override public boolean isAnnotatedAsNullable() {
             return _NullSafe.stream(method.getAnnotations())
                     .map(annot->annot.annotationType().getSimpleName())
                     .anyMatch(name->name.equals("Nullable"));
         }
-
+        @Override public String toString() {
+            return method.toString();
+        }
     }
 
+    @lombok.Value
+    private final static class ParamsAsTupleMethod implements MethodFacade {
+
+        private final Constructor<?> patConstructor;
+        private final Method method;
+
+        @Override public Class<?>[] getParameterTypes() {
+            return patConstructor.getParameterTypes();
+        }
+        @Override public Class<?> getParameterType(final int paramNum) {
+            return patConstructor.getParameterTypes()[paramNum];
+        }
+        @Override public int getParameterCount() {
+            return patConstructor.getParameterCount();
+        }
+        @Override public Class<?> getReturnType() {
+            return method.getReturnType();
+        }
+        @Override public String getName() {
+            return method.getName();
+        }
+        @Override public String getParameterName(final int paramNum) {
+            return patConstructor.getParameters()[paramNum].getName();
+        }
+        @Override public Class<?> getDeclaringClass() {
+            return method.getDeclaringClass();
+        }
+        @Override public Optional<Method> asMethod() {
+            // only allowed for regular methods
+            return Optional.empty();
+        }
+        @Override public Method asMethodForIntrospection() {
+            return method;
+        }
+        @Override public Executable asExecutable() {
+            return patConstructor;
+        }
+        @Override @SneakyThrows
+        public Object[] getArguments(final Object[] executionParameters) {
+            // converts input args into a single arg tuple type (PAT semantics)
+            return new Object[] {patConstructor.newInstance(executionParameters)};
+        }
+        @Override public <A extends Annotation> Optional<A> synthesize(final Class<A> annotationType) {
+            return _Annotations.synthesize(method, annotationType);
+        }
+        @Override public <A extends Annotation> Optional<A> synthesizeOnParameter(final Class<A> annotationType, final int paramNum) {
+            return _Annotations.synthesize(patConstructor.getParameters()[paramNum], annotationType);
+        }
+        @Override public boolean isAnnotatedAsNullable() {
+            return _NullSafe.stream(method.getAnnotations())
+                    .map(annot->annot.annotationType().getSimpleName())
+                    .anyMatch(name->name.equals("Nullable"));
+        }
+        @Override public String toString() {
+            return method.toString();
+        }
+    }
+
+    // -- HELPER
+
+    private Method regularMethodForSyntheticElseFail(final Method method) {
+        return _Reflect
+            .lookupRegularMethodForSynthetic(method)
+            .orElseThrow(()->_Exceptions.illegalArgument("cannot resolve syntetic method %s to a regular one", method));
+    }
 
 }

--- a/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
+++ b/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
@@ -100,10 +100,6 @@ public class _MethodFacades {
         <A extends Annotation> Optional<A> synthesize(final Class<A> annotationType);
         <A extends Annotation> Optional<A> synthesizeOnParameter(final Class<A> annotationType, int paramNum);
 
-        @Deprecated // intermediate refactoring step
-        default Method asMethodUnsafe() {
-            return asMethodForIntrospection();
-        }
         default Method asMethodElseFail() {
             return asMethod().orElseThrow(()->
                 _Exceptions.unrecoverable("Framework Bug: unexpeced method-facade, regular variant expected"));

--- a/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
+++ b/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
@@ -43,13 +43,6 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class _MethodFacades {
 
-    @Deprecated
-    public MethodFacade autodetect(final Method method) {
-        return method.getParameterCount()!=0
-                ? new RegularMethod(method) //FIXME check if Parameters-as-Tuple semantics applies
-                : new RegularMethod(method);
-    }
-
     public static MethodFacade paramsAsTuple(final @NonNull Method method, final @NonNull Constructor<?> patConstructor) {
         return new ParamsAsTupleMethod(patConstructor, regularMethodForSyntheticElseFail(method));
     }

--- a/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
+++ b/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
@@ -95,7 +95,8 @@ public class _MethodFacades {
 
         default Method asMethodElseFail() {
             return asMethod().orElseThrow(()->
-                _Exceptions.unrecoverable("Framework Bug: unexpeced method-facade, regular variant expected"));
+                _Exceptions.unrecoverable("Framework Bug: unexpeced method-facade, "
+                        + "regular variant expected: %s", asMethodForIntrospection()));
         }
         boolean isAnnotatedAsNullable();
     }

--- a/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
+++ b/commons/src/main/java/org/apache/causeway/commons/internal/reflection/_MethodFacades.java
@@ -1,0 +1,177 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.commons.internal.reflection;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.apache.causeway.commons.internal.base._NullSafe;
+import org.apache.causeway.commons.internal.exceptions._Exceptions;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * <h1>- internal use only -</h1>
+ * <p>
+ * <b>WARNING</b>: Do <b>NOT</b> use any of the classes provided by this package! <br/>
+ * These may be changed or removed without notice!
+ * <p>
+ * Provides a layer of abstraction on top of the {@link Method} type (Java reflection API).
+ * @since 2.0
+ */
+@UtilityClass
+public class _MethodFacades {
+
+    public MethodFacade autodetect(final Method method) {
+        return method.getParameterCount()!=0
+                ? new RegularMethod(method) //FIXME check if Parameters-as-Tuple semantics applies
+                : new RegularMethod(method);
+    }
+    //eg. for simple JUnit testing
+    public static MethodFacade regular(final Method method) {
+        return new RegularMethod(method);
+    }
+
+    public static interface MethodFacade {
+
+        Class<?>[] getParameterTypes();
+        Class<?> getParameterType(int paramNum);
+        int getParameterCount();
+        Class<?> getReturnType();
+        String getName();
+        String getParameterName(int paramNum);
+        Class<?> getDeclaringClass();
+        Optional<Method> asMethod();
+
+        /**
+         * exposes the underlying method, use with care:
+         * <ul>
+         * <li>to get the method return type</li>
+         * <li>for annotation inspection on the method (as annotated element) - don't use for param annotation processing</li>
+         * <li>for the method-remover</li>
+         * <li>for invocation</li>
+         * </ul>
+         */
+        Method asMethodForIntrospection();
+
+        /**
+         * This is a convenience method for scenarios where a Method or Constructor reference is treated in a generic fashion.
+         * eg. to process parameter annotations.
+         */
+        Executable asExecutable();
+
+        Object[] getArguments(Object[] executionParameters);
+
+        <A extends Annotation> Optional<A> synthesize(final Class<A> annotationType);
+        <A extends Annotation> Optional<A> synthesizeOnParameter(final Class<A> annotationType, int paramNum);
+
+        @Deprecated // intermediate refactoring step
+        default Method asMethodUnsafe() {
+            return asMethodForIntrospection();
+        }
+        default Method asMethodElseFail() {
+            return asMethod().orElseThrow(()->
+                _Exceptions.unrecoverable("Framework Bug: unexpeced method-facade, regular variant expected"));
+        }
+        boolean isAnnotatedAsNullable();
+    }
+
+    @lombok.Value
+    private final static class RegularMethod implements MethodFacade {
+
+        private final Method method;
+
+        @Override
+        public Class<?> getDeclaringClass() {
+            return method.getDeclaringClass();
+        }
+
+        @Override
+        public int getParameterCount() {
+            return method.getParameterCount();
+        }
+
+        @Override
+        public Class<?>[] getParameterTypes() {
+            return method.getParameterTypes();
+        }
+
+        @Override
+        public Class<?> getParameterType(final int paramNum) {
+            return method.getParameterTypes()[paramNum];
+        }
+
+        @Override
+        public String getName() {
+            return method.getName();
+        }
+
+        @Override
+        public Class<?> getReturnType() {
+            return method.getReturnType();
+        }
+
+        @Override
+        public Optional<Method> asMethod() {
+            return Optional.of(method);
+        }
+
+        @Override
+        public Executable asExecutable() {
+            return method;
+        }
+
+        @Override
+        public <A extends Annotation> Optional<A> synthesize(final Class<A> annotationType) {
+            return _Annotations.synthesize(method, annotationType);
+        }
+
+        @Override
+        public Method asMethodForIntrospection() {
+            return method;
+        }
+
+        @Override
+        public String getParameterName(final int paramNum) {
+            return method.getParameters()[paramNum].getName();
+        }
+
+        @Override
+        public <A extends Annotation> Optional<A> synthesizeOnParameter(final Class<A> annotationType, final int paramNum) {
+            return _Annotations.synthesize(method.getParameters()[paramNum], annotationType);
+        }
+
+        @Override
+        public Object[] getArguments(final Object[] executionParameters) {
+            return executionParameters;
+        }
+
+        @Override
+        public boolean isAnnotatedAsNullable() {
+            return _NullSafe.stream(method.getAnnotations())
+                    .map(annot->annot.annotationType().getSimpleName())
+                    .anyMatch(name->name.equals("Nullable"));
+        }
+
+    }
+
+
+}

--- a/core/config/src/main/java/org/apache/causeway/core/config/progmodel/ProgrammingModelConstants.java
+++ b/core/config/src/main/java/org/apache/causeway/core/config/progmodel/ProgrammingModelConstants.java
@@ -66,6 +66,7 @@ import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.commons.internal.reflection._ClassCache;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.commons.internal.reflection._Reflect;
 
 import static org.apache.causeway.commons.internal.reflection._Reflect.Filter.paramAssignableFrom;
@@ -393,22 +394,22 @@ public final class ProgrammingModelConstants {
         /** eg. hideAct() */
         PREFIXED_ACTION_NAME {
             @Override @Nullable
-            String nameFor(final Method actionMethod, final String prefix, final boolean isMixin) {
+            String nameFor(final MethodFacade actionMethod, final String prefix, final boolean isMixin) {
                 return prefix + _Strings.capitalize(actionMethod.getName());
             }
         },
         /** eg. hide() */
         PREFIX_ONLY {
             @Override @Nullable
-            String nameFor(final Method actionMethod, final String prefix, final boolean isMixin) {
+            String nameFor(final MethodFacade actionMethod, final String prefix, final boolean isMixin) {
                 return isMixin
                         // prefix-only notation is restricted to mixins
                         ? prefix
                         : null;
             }
         };
-        abstract @Nullable String nameFor(Method actionMethod, String prefix, boolean isMixin);
-        public static Can<String> namesFor(final Method actionMethod, final String prefix, final boolean isMixin) {
+        abstract @Nullable String nameFor(MethodFacade actionMethod, String prefix, boolean isMixin);
+        public static Can<String> namesFor(final MethodFacade actionMethod, final String prefix, final boolean isMixin) {
             return Stream.of(ActionSupportNaming.values())
                     .map(naming->naming.nameFor(actionMethod, prefix, isMixin))
                     .collect(Can.toCan());
@@ -419,22 +420,22 @@ public final class ProgrammingModelConstants {
         /** eg. hide2Act(..) */
         PREFIX_PARAM_INDEX_ACTION_NAME {
             @Override @Nullable
-            String nameFor(final Method actionMethod, final String prefix, final boolean isMixin, final int paramNum) {
+            String nameFor(final MethodFacade actionMethod, final String prefix, final boolean isMixin, final int paramNum) {
                 return prefix + paramNum + _Strings.capitalize(actionMethod.getName());
             }
         },
         /** eg. hideEmail() .. where email is the referenced parameter's name */
         PREFIXED_PARAM_NAME {
             @Override @Nullable
-            String nameFor(final Method actionMethod, final String prefix, final boolean isMixin, final int paramNum) {
+            String nameFor(final MethodFacade actionMethod, final String prefix, final boolean isMixin, final int paramNum) {
                 return isMixin
                         // no-action-name-reference notation is restricted to mixins
-                        ? prefix + _Strings.capitalize(actionMethod.getParameters()[paramNum].getName())
+                        ? prefix + _Strings.capitalize(actionMethod.getParameterName(paramNum))
                         : null;
             }
         };
-        abstract @Nullable String nameFor(Method actionMethod, String prefix, boolean isMixin, int paramNum);
-        public static Can<IntFunction<String>> namesFor(final Method actionMethod, final String prefix, final boolean isMixin) {
+        abstract @Nullable String nameFor(MethodFacade actionMethod, String prefix, boolean isMixin, int paramNum);
+        public static Can<IntFunction<String>> namesFor(final MethodFacade actionMethod, final String prefix, final boolean isMixin) {
             return Stream.of(ParameterSupportNaming.values())
                     .<IntFunction<String>>map(naming->(paramNum->naming.nameFor(actionMethod, prefix, isMixin, paramNum)))
                     .collect(Can.toCan());
@@ -446,22 +447,22 @@ public final class ProgrammingModelConstants {
         /** eg. hideProp() */
         PREFIXED_MEMBER_NAME {
             @Override @Nullable
-            String nameFor(final Member member, final String prefix, final boolean isMixin) {
-                return prefix + getCapitalizedMemberName(member);
+            String nameFor(final MethodFacade member, final String prefix, final boolean isMixin) {
+                return prefix + getCapitalizedMemberName(member.asMethodForIntrospection());
             }
         },
         /** eg. hide() */
         PREFIX_ONLY {
             @Override @Nullable
-            String nameFor(final Member member, final String prefix, final boolean isMixin) {
+            String nameFor(final MethodFacade member, final String prefix, final boolean isMixin) {
                 return isMixin
                         // prefix-only notation is restricted to mixins
                         ? prefix
                         : null;
             }
         };
-        abstract @Nullable String nameFor(Member member, String prefix, boolean isMixin);
-        public static Can<String> namesFor(final Member member, final String prefix, final boolean isMixin) {
+        abstract @Nullable String nameFor(MethodFacade member, String prefix, boolean isMixin);
+        public static Can<String> namesFor(final MethodFacade member, final String prefix, final boolean isMixin) {
             return Stream.of(MemberSupportNaming.values())
                     .map(naming->naming.nameFor(member, prefix, isMixin))
                     .collect(Can.toCan());

--- a/core/config/src/main/java/org/apache/causeway/core/config/progmodel/ProgrammingModelConstants.java
+++ b/core/config/src/main/java/org/apache/causeway/core/config/progmodel/ProgrammingModelConstants.java
@@ -527,6 +527,10 @@ public final class ProgrammingModelConstants {
         UNKNONW_SORT_WITH_ACTION("${type}: is a (concrete) but UNKNOWN sort, yet has ${actionCount} actions: ${actions}"),
         ACTION_METHOD_OVERLOADING_NOT_ALLOWED("Action method overloading is not allowed, "
                 + "yet ${type} has action(s) that have a the same member name: ${overloadedNames}"),
+        PARAMETER_TUPLE_INVALID_USE_OF_ANNOTATION("${type}#${member}: "
+                + "Can use @ParameterTuple only on parameter of a single arg action."),
+        PARAMETER_TUPLE_TYPE_WITH_AMBIGUOUS_CONSTRUCTORS("${type}#${member}: "
+                + "Tuple type ${patType} referenced by @ParameterTuple annotated parameter has no or more than one public constructor."),
         ;
 
         private final String template;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/commons/CanonicalInvoker.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/commons/CanonicalInvoker.java
@@ -28,6 +28,7 @@ import org.springframework.lang.Nullable;
 import org.apache.causeway.commons.internal.base._Casts;
 import org.apache.causeway.commons.internal.base._NullSafe;
 import org.apache.causeway.commons.internal.collections._Arrays;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.commons.internal.reflection._Reflect;
 
 import lombok.Builder;
@@ -87,6 +88,11 @@ public class CanonicalInvoker {
     }
 
     // -- INVOKE
+
+    public static Object invoke(final MethodFacade methodFacade, final Object targetPojo, final Object[] executionParameters) {
+        return CanonicalInvoker.invoke(
+                methodFacade.asMethodForIntrospection(), targetPojo, methodFacade.getArguments(executionParameters));
+    }
 
     public void invokeAll(final Iterable<Method> methods, final Object object) {
         methods.forEach(method->invoke(method, object));

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/execution/MemberExecutorService.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/execution/MemberExecutorService.java
@@ -18,13 +18,13 @@
  */
 package org.apache.causeway.core.metamodel.execution;
 
-import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.apache.causeway.applib.services.iactn.ActionInvocation;
 import org.apache.causeway.applib.services.iactn.PropertyEdit;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.properties.property.modify.PropertySetterOrClearFacetForDomainEventAbstract.EditingVariant;
@@ -86,7 +86,7 @@ public interface MemberExecutorService {
             @NonNull InteractionHead head,
             @NonNull Can<ManagedObject> argumentAdapters,
             @NonNull InteractionInitiatedBy interactionInitiatedBy,
-            @NonNull Method method,
+            @NonNull MethodFacade method,
             @NonNull ActionExecutorFactory actionExecutorFactory,
             @NonNull FacetHolder facetHolder);
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facetapi/FeatureType.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facetapi/FeatureType.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Method;
 import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.commons.collections.ImmutableEnumSet;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.commons.StringExtensions;
 import org.apache.causeway.core.metamodel.facets.FacetFactory;
 
@@ -42,25 +43,25 @@ public enum FeatureType {
          * The supplied method can be null; at any rate it will be ignored.
          */
         @Override
-        public Identifier identifierFor(final LogicalType typeIdentifier, final Method method) {
+        public Identifier identifierFor(final LogicalType typeIdentifier, final MethodFacade method) {
             return Identifier.classIdentifier(typeIdentifier);
         }
     },
     PROPERTY("Property") {
         @Override
-        public Identifier identifierFor(final LogicalType typeIdentifier, final Method method) {
-            return propertyIdentifierFor(typeIdentifier, method);
+        public Identifier identifierFor(final LogicalType typeIdentifier, final MethodFacade method) {
+            return propertyIdentifierFor(typeIdentifier, method.asMethodElseFail()); // expected regular
         }
     },
     COLLECTION("Collection") {
         @Override
-        public Identifier identifierFor(final LogicalType typeIdentifier, final Method method) {
-            return collectionIdentifierFor(typeIdentifier, method);
+        public Identifier identifierFor(final LogicalType typeIdentifier, final MethodFacade method) {
+            return collectionIdentifierFor(typeIdentifier, method.asMethodElseFail()); // expected regular
         }
     },
     ACTION("Action") {
         @Override
-        public Identifier identifierFor(final LogicalType typeIdentifier, final Method method) {
+        public Identifier identifierFor(final LogicalType typeIdentifier, final MethodFacade method) {
             final String fullMethodName = method.getName();
             final Class<?>[] parameterTypes = method.getParameterTypes();
             return Identifier.actionIdentifier(typeIdentifier, fullMethodName, parameterTypes);
@@ -71,7 +72,7 @@ public enum FeatureType {
          * Always returns <tt>null</tt>.
          */
         @Override
-        public Identifier identifierFor(final LogicalType typeIdentifier, final Method method) {
+        public Identifier identifierFor(final LogicalType typeIdentifier, final MethodFacade method) {
             return null;
         }
     },
@@ -80,7 +81,7 @@ public enum FeatureType {
          * Always returns <tt>null</tt>.
          */
         @Override
-        public Identifier identifierFor(final LogicalType typeIdentifier, final Method method) {
+        public Identifier identifierFor(final LogicalType typeIdentifier, final MethodFacade method) {
             return null;
         }
     };
@@ -150,7 +151,7 @@ public enum FeatureType {
         return isProperty() || isCollection();
     }
 
-    public abstract Identifier identifierFor(LogicalType typeIdentifier, Method method);
+    public abstract Identifier identifierFor(LogicalType typeIdentifier, MethodFacade method);
 
     @Override
     public String toString() {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetFactory.java
@@ -352,7 +352,7 @@ public interface FacetFactory {
                 final MethodRemover methodRemover,
                 final FacetedMethod facetedMethod) {
             return new ProcessMethodContext(
-                    cls, IntrospectionPolicy.ANNOTATION_OPTIONAL, featureType, _MethodFacades.autodetect(method),
+                    cls, IntrospectionPolicy.ANNOTATION_OPTIONAL, featureType, _MethodFacades.regular(method),
                     methodRemover, facetedMethod, false);
         }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethod.java
@@ -217,7 +217,7 @@ extends TypedHolderAbstract {
                 featureType.identifierFor(LogicalType.lazy(
                         declaringType,
                         ()->mmc.getSpecificationLoader().specForTypeElseFail(declaringType).getLogicalTypeName()),
-                    method.asMethodForIntrospection()));
+                    method));
         this.owningType = declaringType;
         this.method = method;
         this.parameters = parameters;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethod.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.collections._Lists;
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants;
 import org.apache.causeway.core.metamodel.commons.StringExtensions;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
@@ -46,23 +48,25 @@ extends TypedHolderAbstract {
     public static FacetedMethod createForProperty(
             final MetaModelContext mmc,
             final Class<?> declaringType,
-            final Method method) {
+            final Method getterMethod) {
+        val methodFacade = _MethodFacades.regular(getterMethod);
         return new FacetedMethod(mmc, FeatureType.PROPERTY,
-                declaringType, method, TypeOfAnyCardinality.forMethodReturn(declaringType, method), Can.empty());
+                declaringType, methodFacade, TypeOfAnyCardinality.forMethodReturn(declaringType, getterMethod), Can.empty());
     }
 
     public static FacetedMethod createForCollection(
             final MetaModelContext mmc,
             final Class<?> declaringType,
-            final Method method) {
+            final Method getterMethod) {
+        val methodFacade = _MethodFacades.regular(getterMethod);
         return new FacetedMethod(mmc, FeatureType.COLLECTION,
-                declaringType, method, TypeOfAnyCardinality.forMethodReturn(declaringType, method), Can.empty());
+                declaringType, methodFacade, TypeOfAnyCardinality.forMethodReturn(declaringType, getterMethod), Can.empty());
     }
 
     public static FacetedMethod createForAction(
             final MetaModelContext mmc,
             final Class<?> declaringType,
-            final Method method) {
+            final MethodFacade method) {
         return new FacetedMethod(mmc, FeatureType.ACTION,
                 declaringType, method, TypeOfAnyCardinality.forMethodReturn(declaringType, method),
                 getParameters(mmc, declaringType, method));
@@ -71,18 +75,16 @@ extends TypedHolderAbstract {
     private static Can<FacetedMethodParameter> getParameters(
             final MetaModelContext mmc,
             final Class<?> declaringType,
-            final Method actionMethod) {
+            final MethodFacade actionMethod) {
 
         final List<FacetedMethodParameter> actionParams =
                 _Lists.newArrayList(actionMethod.getParameterCount());
 
         int paramIndex = -1;
 
-        for(val param : actionMethod.getParameters()) {
+        for(val parameterType : actionMethod.getParameterTypes()) {
 
             paramIndex++;
-
-            final Class<?> parameterType = param.getType();
 
             final FeatureType featureType =
                     ProgrammingModelConstants.CollectionSemantics.valueOf(parameterType).isPresent()
@@ -169,7 +171,7 @@ extends TypedHolderAbstract {
             final Class<?>... parameterTypes) {
 
         try {
-            final Method method = declaringType.getMethod(actionName, parameterTypes);
+            val method = _MethodFacades.regular(declaringType.getMethod(actionName, parameterTypes));
             return FacetedMethod.createForAction(mmc, declaringType, method);
         } catch (final SecurityException | NoSuchMethodException e) {
             throw new RuntimeException(e);
@@ -195,7 +197,7 @@ extends TypedHolderAbstract {
      * A {@link Method} obtained from the {@link #getOwningType() owning type}
      * using {@link Class#getMethods()}.
      */
-    @Getter private final Method method;
+    @Getter private final MethodFacade method;
 
     @Getter private final Can<FacetedMethodParameter> parameters;
 
@@ -205,7 +207,7 @@ extends TypedHolderAbstract {
             final MetaModelContext mmc,
             final FeatureType featureType,
             final Class<?> declaringType,
-            final Method method,
+            final MethodFacade method,
             final TypeOfAnyCardinality type,
             final Can<FacetedMethodParameter> parameters) {
 
@@ -214,7 +216,8 @@ extends TypedHolderAbstract {
                 type,
                 featureType.identifierFor(LogicalType.lazy(
                         declaringType,
-                        ()->mmc.getSpecificationLoader().specForTypeElseFail(declaringType).getLogicalTypeName()), method));
+                        ()->mmc.getSpecificationLoader().specForTypeElseFail(declaringType).getLogicalTypeName()),
+                    method.asMethodForIntrospection()));
         this.owningType = declaringType;
         this.method = method;
         this.parameters = parameters;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethod.java
@@ -66,10 +66,10 @@ extends TypedHolderAbstract {
     public static FacetedMethod createForAction(
             final MetaModelContext mmc,
             final Class<?> declaringType,
-            final MethodFacade method) {
+            final MethodFacade methodFacade) {
         return new FacetedMethod(mmc, FeatureType.ACTION,
-                declaringType, method, TypeOfAnyCardinality.forMethodReturn(declaringType, method),
-                getParameters(mmc, declaringType, method));
+                declaringType, methodFacade, TypeOfAnyCardinality.forMethodFacadeReturn(declaringType, methodFacade),
+                getParameters(mmc, declaringType, methodFacade));
     }
 
     private static Can<FacetedMethodParameter> getParameters(

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethodParameter.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethodParameter.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.applib.id.LogicalType;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.facetapi.FeatureType;
 import org.apache.causeway.core.metamodel.spec.TypeOfAnyCardinality;
@@ -36,7 +35,7 @@ extends TypedHolderAbstract {
             final MetaModelContext mmc,
             final FeatureType featureType,
             final Class<?> declaringType,
-            final Method method,
+            final MethodFacade method,
             final int paramIndex) {
 
         super(mmc,
@@ -46,7 +45,7 @@ extends TypedHolderAbstract {
                         LogicalType.lazy(
                                 declaringType,
                                 ()->mmc.getSpecificationLoader().loadSpecification(declaringType).getLogicalTypeName()),
-                        method));
+                        method.asMethodForIntrospection()));
 
         this.paramIndex = paramIndex;
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethodParameter.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethodParameter.java
@@ -35,17 +35,17 @@ extends TypedHolderAbstract {
             final MetaModelContext mmc,
             final FeatureType featureType,
             final Class<?> declaringType,
-            final MethodFacade method,
+            final MethodFacade methodFacade,
             final int paramIndex) {
 
         super(mmc,
                 featureType,
-                TypeOfAnyCardinality.forMethodParameter(declaringType, method, paramIndex),
+                TypeOfAnyCardinality.forMethodFacadeParameter(declaringType, methodFacade, paramIndex),
                 FeatureType.ACTION.identifierFor(
                         LogicalType.lazy(
                                 declaringType,
                                 ()->mmc.getSpecificationLoader().loadSpecification(declaringType).getLogicalTypeName()),
-                        method.asMethodForIntrospection()));
+                        methodFacade.asMethodForIntrospection()));
 
         this.paramIndex = paramIndex;
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethodParameter.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/FacetedMethodParameter.java
@@ -45,7 +45,7 @@ extends TypedHolderAbstract {
                         LogicalType.lazy(
                                 declaringType,
                                 ()->mmc.getSpecificationLoader().loadSpecification(declaringType).getLogicalTypeName()),
-                        methodFacade.asMethodForIntrospection()));
+                        methodFacade));
 
         this.paramIndex = paramIndex;
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/HasImperativeAspect.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/HasImperativeAspect.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 
 public interface HasImperativeAspect
 extends ImperativeFacet {
@@ -28,13 +27,13 @@ extends ImperativeFacet {
     ImperativeAspect getImperativeAspect();
 
     @Override
-    default Can<Method> getMethods() {
+    default Can<MethodFacade> getMethods() {
         return getImperativeAspect().getMethods();
     }
 
     @Override
-    default Intent getIntent(final Method method) {
-        return getImperativeAspect().getIntent(method);
+    default Intent getIntent() {
+        return getImperativeAspect().getIntent();
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actcoll/typeof/TypeOfFacet.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actcoll/typeof/TypeOfFacet.java
@@ -57,7 +57,7 @@ public interface TypeOfFacet extends Facet {
             final MethodFacade method,
             final int paramIndex,
             final FacetHolder holder) {
-        val type = TypeOfAnyCardinality.forMethodParameter(implementationClass, method, paramIndex);
+        val type = TypeOfAnyCardinality.forMethodFacadeParameter(implementationClass, method, paramIndex);
         return toInferredFrom(TypeOfFacet::inferredFromFeature, type, holder);
     }
 
@@ -65,7 +65,7 @@ public interface TypeOfFacet extends Facet {
             final Class<?> implementationClass,
             final MethodFacade method,
             final FacetHolder holder) {
-        val type = TypeOfAnyCardinality.forMethodReturn(implementationClass, method);
+        val type = TypeOfAnyCardinality.forMethodFacadeReturn(implementationClass, method);
         return toInferredFrom(TypeOfFacet::inferredFromFeature, type, holder);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actcoll/typeof/TypeOfFacet.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actcoll/typeof/TypeOfFacet.java
@@ -18,11 +18,11 @@
  */
 package org.apache.causeway.core.metamodel.facets.actcoll.typeof;
 
-import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
 import org.apache.causeway.applib.annotation.Collection;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants.CollectionSemantics;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
@@ -54,7 +54,7 @@ public interface TypeOfFacet extends Facet {
 
     static Optional<TypeOfFacet> inferFromMethodParameter(
             final Class<?> implementationClass,
-            final Method method,
+            final MethodFacade method,
             final int paramIndex,
             final FacetHolder holder) {
         val type = TypeOfAnyCardinality.forMethodParameter(implementationClass, method, paramIndex);
@@ -63,7 +63,7 @@ public interface TypeOfFacet extends Facet {
 
     static Optional<TypeOfFacet> inferFromMethodReturnType(
             final Class<?> implementationClass,
-            final Method method,
+            final MethodFacade method,
             final FacetHolder holder) {
         val type = TypeOfAnyCardinality.forMethodReturn(implementationClass, method);
         return toInferredFrom(TypeOfFacet::inferredFromFeature, type, holder);

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/ActionAnnotationFacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/ActionAnnotationFacetFactory.java
@@ -150,7 +150,7 @@ extends FacetFactoryAbstract {
                             actionDomainEventFacet.getEventType(), actionMethod, typeSpec, returnSpec, holder));
 
         } finally {
-            processMethodContext.removeMethod(actionMethod);
+            processMethodContext.removeMethod(actionMethod.asMethodForIntrospection());
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/invocation/ActionInvocationFacetForDomainEventAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/invocation/ActionInvocationFacetForDomainEventAbstract.java
@@ -33,6 +33,7 @@ import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.functional.Try;
 import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.commons.internal.collections._Arrays;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.commons.CanonicalInvoker;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.execution.InteractionInternal;
@@ -67,14 +68,14 @@ implements ImperativeFacet {
 
     public ActionInvocationFacetForDomainEventAbstract(
             final Class<? extends ActionDomainEvent<?>> eventType,
-            final Method method,
+            final MethodFacade method,
             final ObjectSpecification declaringType,
             final ObjectSpecification returnType,
             final FacetHolder holder) {
 
         super(holder);
         this.eventType = eventType;
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleMethod(method.asMethodUnsafe());
         this.declaringType = declaringType;
         this.returnType = returnType;
         this.serviceRegistry = getServiceRegistry();

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/invocation/ActionInvocationFacetForDomainEventAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/invocation/ActionInvocationFacetForDomainEventAbstract.java
@@ -19,7 +19,6 @@
 package org.apache.causeway.core.metamodel.facets.actions.action.invocation;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -60,7 +59,7 @@ extends ActionInvocationFacetAbstract
 implements ImperativeFacet {
 
     @Getter private final Class<? extends ActionDomainEvent<?>> eventType;
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     @Getter(onMethod = @__(@Override)) private final ObjectSpecification declaringType;
     @Getter(onMethod = @__(@Override)) private final ObjectSpecification returnType;
     private final ServiceRegistry serviceRegistry;
@@ -75,7 +74,7 @@ implements ImperativeFacet {
 
         super(holder);
         this.eventType = eventType;
-        this.methods = ImperativeFacet.singleMethod(method.asMethodUnsafe());
+        this.methods = ImperativeFacet.singleMethod(method);
         this.declaringType = declaringType;
         this.returnType = returnType;
         this.serviceRegistry = getServiceRegistry();
@@ -83,7 +82,7 @@ implements ImperativeFacet {
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.EXECUTE;
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/invocation/ActionInvocationFacetForDomainEventFromActionAnnotation.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/invocation/ActionInvocationFacetForDomainEventFromActionAnnotation.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.actions.action.invocation;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.applib.events.domain.ActionDomainEvent;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
 
@@ -29,7 +28,7 @@ extends ActionInvocationFacetForDomainEventAbstract {
 
     public ActionInvocationFacetForDomainEventFromActionAnnotation(
             final Class<? extends ActionDomainEvent<?>> eventType,
-            final Method method,
+            final MethodFacade method,
             final ObjectSpecification onType,
             final ObjectSpecification returnType,
             final FacetHolder holder) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/invocation/ActionInvocationFacetForDomainEventFromDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/action/invocation/ActionInvocationFacetForDomainEventFromDefault.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.actions.action.invocation;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.applib.events.domain.ActionDomainEvent;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
 
@@ -29,7 +28,7 @@ extends ActionInvocationFacetForDomainEventAbstract {
 
     public ActionInvocationFacetForDomainEventFromDefault(
             final Class<? extends ActionDomainEvent<?>> eventType,
-            final Method method,
+            final MethodFacade method,
             final ObjectSpecification onType,
             final ObjectSpecification returnType,
             final FacetHolder holder) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/notinservicemenu/derived/NotInServiceMenuFacetFromDomainServiceFacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/notinservicemenu/derived/NotInServiceMenuFacetFromDomainServiceFacetFactory.java
@@ -18,8 +18,6 @@
  */
 package org.apache.causeway.core.metamodel.facets.actions.notinservicemenu.derived;
 
-import java.lang.reflect.Method;
-
 import javax.inject.Inject;
 
 import org.apache.causeway.applib.annotation.NatureOfService;
@@ -30,6 +28,8 @@ import org.apache.causeway.core.metamodel.facets.FacetFactoryAbstract;
 import org.apache.causeway.core.metamodel.facets.FacetedMethod;
 import org.apache.causeway.core.metamodel.facets.object.domainservice.DomainServiceFacet;
 import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
+
+import lombok.val;
 
 public class NotInServiceMenuFacetFromDomainServiceFacetFactory
 extends FacetFactoryAbstract {
@@ -42,7 +42,7 @@ extends FacetFactoryAbstract {
     @Override
     public void process(final ProcessMethodContext processMethodContext) {
 
-        final Method method = processMethodContext.getMethod();
+        val method = processMethodContext.getMethod();
         final Class<?> declaringClass = method.getDeclaringClass();
         final ObjectSpecification spec = getSpecificationLoader().loadSpecification(declaringClass);
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/validate/method/ActionParameterValidationFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/validate/method/ActionParameterValidationFacetViaMethod.java
@@ -25,6 +25,7 @@ import org.apache.causeway.applib.services.i18n.TranslatableString;
 import org.apache.causeway.applib.services.i18n.TranslationContext;
 import org.apache.causeway.applib.services.i18n.TranslationService;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.facets.actions.validate.ActionParameterValidationFacetAbstract;
@@ -39,26 +40,29 @@ public class ActionParameterValidationFacetViaMethod
 extends ActionParameterValidationFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final TranslationService translationService;
     private final TranslationContext translationContext;
 
-    public ActionParameterValidationFacetViaMethod(final Method method, final TranslationService translationService,
-    		final TranslationContext translationContext, final FacetHolder holder) {
+    public ActionParameterValidationFacetViaMethod(
+            final Method method,
+            final TranslationService translationService,
+    		final TranslationContext translationContext,
+    		final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
         this.translationService = translationService;
         this.translationContext = translationContext;
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHECK_IF_VALID;
     }
 
     @Override
     public String invalidReason(final ManagedObject owningAdapter, final ManagedObject proposedArgumentAdapter) {
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         final Object returnValue = MmInvokeUtil.invoke(method, owningAdapter, proposedArgumentAdapter);
         if(returnValue instanceof String) {
             return (String) returnValue;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/validate/method/ActionValidationFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/validate/method/ActionValidationFacetViaMethod.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import org.apache.causeway.applib.services.i18n.TranslatableString;
 import org.apache.causeway.applib.services.i18n.TranslationContext;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.facets.actions.validate.ActionValidationFacetAbstract;
@@ -40,7 +41,7 @@ public class ActionValidationFacetViaMethod
 extends ActionValidationFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final TranslationContext translationContext;
     private final Optional<Constructor<?>> patConstructor;
 
@@ -50,13 +51,13 @@ implements ImperativeFacet {
             final FacetHolder holder) {
 
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleMethod(method, patConstructor);
         this.translationContext = holder.getTranslationContext();
         this.patConstructor = patConstructor;
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHECK_IF_VALID;
     }
 
@@ -64,9 +65,7 @@ implements ImperativeFacet {
     public String invalidReason(final ManagedObject owningAdapter, final Can<ManagedObject> proposedArgumentAdapters) {
 
         val method = methods.getFirstElseFail();
-        final Object returnValue = patConstructor.isPresent()
-                ? MmInvokeUtil.invokeWithPAT(patConstructor.get(), method, owningAdapter, proposedArgumentAdapters)
-                : MmInvokeUtil.invoke(method, owningAdapter, proposedArgumentAdapters);
+        final Object returnValue = MmInvokeUtil.invoke(patConstructor, method, owningAdapter, proposedArgumentAdapters);
 
         if(returnValue instanceof String) {
             return (String) returnValue;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/validate/method/ActionValidationFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/actions/validate/method/ActionValidationFacetViaMethod.java
@@ -65,7 +65,7 @@ implements ImperativeFacet {
     public String invalidReason(final ManagedObject owningAdapter, final Can<ManagedObject> proposedArgumentAdapters) {
 
         val method = methods.getFirstElseFail();
-        final Object returnValue = MmInvokeUtil.invoke(patConstructor, method, owningAdapter, proposedArgumentAdapters);
+        final Object returnValue = MmInvokeUtil.invokeNoAutofit(patConstructor, method, owningAdapter, proposedArgumentAdapters);
 
         if(returnValue instanceof String) {
             return (String) returnValue;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/collections/accessor/CollectionAccessorFacetViaAccessor.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/collections/accessor/CollectionAccessorFacetViaAccessor.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
@@ -39,18 +40,18 @@ public class CollectionAccessorFacetViaAccessor
 extends PropertyOrCollectionAccessorFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     public CollectionAccessorFacetViaAccessor(
             final ObjectSpecification declaringType,
             final Method method,
             final FacetHolder holder) {
         super(declaringType, holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.ACCESSOR;
     }
 
@@ -59,7 +60,7 @@ implements ImperativeFacet {
             final ManagedObject owningAdapter,
             final InteractionInitiatedBy interactionInitiatedBy) {
 
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         final Object collectionOrArray = MmInvokeUtil.invoke(method, owningAdapter);
         if(collectionOrArray == null) {
             return null;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/collections/accessor/CollectionAccessorFacetViaAccessorFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/collections/accessor/CollectionAccessorFacetViaAccessorFactory.java
@@ -49,7 +49,7 @@ extends PropertyOrCollectionIdentifyingFacetFactoryAbstract {
     }
 
     private void attachAccessorFacetForAccessorMethod(final ProcessMethodContext processMethodContext) {
-        final Method accessorMethod = processMethodContext.getMethod();
+        val accessorMethod = processMethodContext.getMethod().asMethodElseFail(); // no-arg method, should have a regular facade
         processMethodContext.removeMethod(accessorMethod);
 
         val cls = processMethodContext.getCls();

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/members/cssclass/annotprop/CssClassFacetOnActionFromConfiguredRegexFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/members/cssclass/annotprop/CssClassFacetOnActionFromConfiguredRegexFactory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.causeway.core.metamodel.facets.members.cssclass.annotprop;
 
-import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -31,6 +30,8 @@ import org.apache.causeway.core.metamodel.facetapi.FeatureType;
 import org.apache.causeway.core.metamodel.facets.FacetFactoryAbstract;
 import org.apache.causeway.core.metamodel.facets.FacetedMethod;
 import org.apache.causeway.core.metamodel.facets.members.cssclass.CssClassFacet;
+
+import lombok.val;
 
 public class CssClassFacetOnActionFromConfiguredRegexFactory
 extends FacetFactoryAbstract {
@@ -51,7 +52,7 @@ extends FacetFactoryAbstract {
             return;
         }
 
-        final Method method = processMethodContext.getMethod();
+        val method = processMethodContext.getMethod();
         final String name = method.getName();
 
         addFacetIfPresent(createFromConfiguredRegexIfPossible(name, facetHolder));

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/members/disabled/method/DisableForContextFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/members/disabled/method/DisableForContextFacetViaMethod.java
@@ -24,6 +24,7 @@ import java.util.function.BiConsumer;
 import org.apache.causeway.applib.services.i18n.TranslatableString;
 import org.apache.causeway.applib.services.i18n.TranslationContext;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.interactions.UsabilityContext;
@@ -38,19 +39,19 @@ public class DisableForContextFacetViaMethod
 extends DisableForContextFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final TranslationContext translationContext;
 
     public DisableForContextFacetViaMethod(
             final Method method,
             final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
         this.translationContext = holder.getTranslationContext();
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHECK_IF_DISABLED;
     }
 
@@ -63,7 +64,7 @@ implements ImperativeFacet {
         if (target == null) {
             return null;
         }
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         final Object returnValue = MmInvokeUtil.invokeAutofit(method, target);
         if(returnValue instanceof String) {
             return (String) returnValue;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/members/hidden/method/HideForContextFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/members/hidden/method/HideForContextFacetViaMethod.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.interactions.VisibilityContext;
@@ -36,15 +37,15 @@ public class HideForContextFacetViaMethod
 extends HideForContextFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     public HideForContextFacetViaMethod(final Method method, final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHECK_IF_HIDDEN;
     }
 
@@ -54,7 +55,7 @@ implements ImperativeFacet {
         if (target == null) {
             return null;
         }
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         final Boolean isHidden = (Boolean) MmInvokeUtil.invokeAutofit(method, target);
         return isHidden.booleanValue() ? "Hidden" : null;
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/CallbackFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/CallbackFacetAbstract.java
@@ -21,7 +21,7 @@ package org.apache.causeway.core.metamodel.facets.object.callbacks;
 import java.lang.reflect.Method;
 
 import org.apache.causeway.commons.collections.Can;
-import org.apache.causeway.commons.internal.reflection._Reflect;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetAbstract;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
@@ -38,27 +38,26 @@ extends FacetAbstract
 implements CallbackFacet {
 
     @Getter(onMethod_ = {@Override})
-    private final Can<Method> methods;
+    private final Can<MethodFacade> methods;
+    private final Can<Method> asRegularMethods;
 
     protected CallbackFacetAbstract(
             final Class<? extends Facet> facetType,
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(facetType, holder);
-        this.methods = methods
-                .map(method->_Reflect.lookupRegularMethodForSynthetic(method).orElse(null));
+        this.methods = methods;
+        this.asRegularMethods = methods.map(MethodFacade::asMethodElseFail); // all expected to be regular
     }
 
     @Override
-    public final Intent getIntent(final Method method) {
+    public final Intent getIntent() {
         return Intent.LIFECYCLE;
     }
 
     @Override
     public final void invoke(final ManagedObject adapter) {
-        // as a side effect memoizes the list of methods and locks it so cannot add any more
-        MmInvokeUtil.invokeAll(getMethods(), adapter);
+        MmInvokeUtil.invokeAll(asRegularMethods, adapter);
     }
-
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/CallbackFacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/CallbackFacetFactory.java
@@ -18,13 +18,14 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants.CallbackMethod;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
@@ -60,21 +61,21 @@ extends MethodPrefixBasedFacetFactoryAbstract {
     private void processCallback(
             final ProcessClassContext processClassContext,
             final CallbackMethod callbackMethodEnum,
-            final BiFunction<Can<Method>, FacetHolder, CallbackFacet> callbackFacetConstructor) {
+            final BiFunction<Can<MethodFacade>, FacetHolder, CallbackFacet> callbackFacetConstructor) {
         val cls = processClassContext.getCls();
         val facetHolder = processClassContext.getFacetHolder();
 
         val callbackMethods =
-
-        MethodFinder
-        .livecycleCallback(
-                cls,
-                callbackMethodEnum.getMethodNames(),
-                processClassContext.getIntrospectionPolicy())
-        .withRequiredReturnType(void.class)
-        .streamMethodsMatchingSignature(NO_ARG)
-        .peek(processClassContext::removeMethod)
-        .collect(Can.toCan());
+            MethodFinder
+            .livecycleCallback(
+                    cls,
+                    callbackMethodEnum.getMethodNames(),
+                    processClassContext.getIntrospectionPolicy())
+            .withRequiredReturnType(void.class)
+            .streamMethodsMatchingSignature(NO_ARG)
+            .peek(processClassContext::removeMethod)
+            .map(_MethodFacades::regular)
+            .collect(Can.toCan());
 
         if(callbackMethods.isNotEmpty()) {
             addFacet(callbackFacetConstructor.apply(callbackMethods, facetHolder));

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/CreatedCallbackFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/CreatedCallbackFacetAbstract.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
@@ -33,7 +32,7 @@ implements CreatedCallbackFacet {
     }
 
     public CreatedCallbackFacetAbstract(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(type(), methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/CreatedCallbackFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/CreatedCallbackFacetViaMethod.java
@@ -21,6 +21,7 @@ package org.apache.causeway.core.metamodel.facets.object.callbacks;
 import java.lang.reflect.Method;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 
@@ -29,7 +30,7 @@ extends CreatedCallbackFacetAbstract
 implements ImperativeFacet {
 
     public CreatedCallbackFacetViaMethod(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/LoadedCallbackFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/LoadedCallbackFacetAbstract.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
@@ -33,7 +32,7 @@ implements LoadedCallbackFacet {
     }
 
     public LoadedCallbackFacetAbstract(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(type(), methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/LoadedCallbackFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/LoadedCallbackFacetViaMethod.java
@@ -18,16 +18,15 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
 public class LoadedCallbackFacetViaMethod
 extends LoadedCallbackFacetAbstract {
 
     public LoadedCallbackFacetViaMethod(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/PersistedCallbackFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/PersistedCallbackFacetAbstract.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
@@ -33,7 +32,7 @@ implements PersistedCallbackFacet {
     }
 
     public PersistedCallbackFacetAbstract(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(type(), methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/PersistedCallbackFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/PersistedCallbackFacetViaMethod.java
@@ -18,16 +18,15 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
 public class PersistedCallbackFacetViaMethod
 extends PersistedCallbackFacetAbstract {
 
     public PersistedCallbackFacetViaMethod(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/PersistingCallbackFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/PersistingCallbackFacetAbstract.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
@@ -33,7 +32,7 @@ implements PersistingCallbackFacet {
     }
 
     public PersistingCallbackFacetAbstract(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(type(), methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/PersistingCallbackFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/PersistingCallbackFacetViaMethod.java
@@ -18,16 +18,15 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
 public class PersistingCallbackFacetViaMethod
 extends PersistingCallbackFacetAbstract {
 
     public PersistingCallbackFacetViaMethod(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/RemovingCallbackFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/RemovingCallbackFacetAbstract.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
@@ -33,7 +32,7 @@ implements RemovingCallbackFacet {
     }
 
     public RemovingCallbackFacetAbstract(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(type(), methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/RemovingCallbackFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/RemovingCallbackFacetViaMethod.java
@@ -18,16 +18,15 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
 public class RemovingCallbackFacetViaMethod
 extends RemovingCallbackFacetAbstract {
 
     public RemovingCallbackFacetViaMethod(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/UpdatedCallbackFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/UpdatedCallbackFacetAbstract.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
@@ -33,7 +32,7 @@ implements UpdatedCallbackFacet {
     }
 
     public UpdatedCallbackFacetAbstract(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(type(), methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/UpdatedCallbackFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/UpdatedCallbackFacetViaMethod.java
@@ -18,16 +18,15 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
 public class UpdatedCallbackFacetViaMethod
 extends UpdatedCallbackFacetAbstract {
 
     public UpdatedCallbackFacetViaMethod(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/UpdatingCallbackFacetAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/UpdatingCallbackFacetAbstract.java
@@ -18,9 +18,8 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
@@ -33,7 +32,7 @@ implements UpdatingCallbackFacet {
     }
 
     public UpdatingCallbackFacetAbstract(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(type(), methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/UpdatingCallbackFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/callbacks/UpdatingCallbackFacetViaMethod.java
@@ -18,16 +18,15 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.callbacks;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 
 public class UpdatingCallbackFacetViaMethod
 extends UpdatingCallbackFacetAbstract {
 
     public UpdatingCallbackFacetViaMethod(
-            final Can<Method> methods,
+            final Can<MethodFacade> methods,
             final FacetHolder holder) {
         super(methods, holder);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/cssclass/method/CssClassFacetViaCssClassMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/cssclass/method/CssClassFacetViaCssClassMethod.java
@@ -47,7 +47,7 @@ implements HasImperativeAspect {
         return Optional.ofNullable(methodIfAny)
         .map(method->
             new CssClassFacetViaCssClassMethod(
-                    ImperativeAspect.singleMethod(method, Intent.UI_HINT),
+                    ImperativeAspect.singleRegularMethod(method, Intent.UI_HINT),
                     holder));
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/disabled/method/DisabledObjectFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/disabled/method/DisabledObjectFacetViaMethod.java
@@ -52,7 +52,7 @@ implements HasImperativeAspect {
         return Optional.ofNullable(methodIfAny)
         .map(method->
             new DisabledObjectFacetViaMethod(
-                    ImperativeAspect.singleMethod(method, Intent.CHECK_IF_DISABLED),
+                    ImperativeAspect.singleRegularMethod(method, Intent.CHECK_IF_DISABLED),
                     TranslationContext.forMethod(method),
                     holder));
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/hidden/method/HiddenObjectFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/hidden/method/HiddenObjectFacetViaMethod.java
@@ -46,7 +46,7 @@ implements HasImperativeAspect {
             final FacetHolder holder) {
 
         return Optional.ofNullable(methodIfAny)
-        .map(method->ImperativeAspect.singleMethod(method, Intent.CHECK_IF_HIDDEN))
+        .map(method->ImperativeAspect.singleRegularMethod(method, Intent.CHECK_IF_HIDDEN))
         .map(imperativeAspect->new HiddenObjectFacetViaMethod(imperativeAspect, holder));
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/icon/method/IconFacetViaIconNameMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/icon/method/IconFacetViaIconNameMethod.java
@@ -47,7 +47,7 @@ implements HasImperativeAspect {
         return Optional.ofNullable(methodIfAny)
         .map(method->
             new IconFacetViaIconNameMethod(
-                    ImperativeAspect.singleMethod(method, Intent.UI_HINT),
+                    ImperativeAspect.singleRegularMethod(method, Intent.UI_HINT),
                     holder));
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/layout/LayoutFacetViaLayoutMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/layout/LayoutFacetViaLayoutMethod.java
@@ -46,7 +46,7 @@ implements HasImperativeAspect {
         return Optional.ofNullable(methodIfAny)
         .map(method->
             new LayoutFacetViaLayoutMethod(
-                    ImperativeAspect.singleMethod(method, Intent.UI_HINT),
+                    ImperativeAspect.singleRegularMethod(method, Intent.UI_HINT),
                     holder));
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/title/annotation/TitleFacetViaTitleAnnotation.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/title/annotation/TitleFacetViaTitleAnnotation.java
@@ -19,7 +19,6 @@
 package org.apache.causeway.core.metamodel.facets.object.title.annotation;
 
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +31,8 @@ import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.commons.internal.compare._Comparators;
 import org.apache.causeway.commons.internal.reflection._Annotations;
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.commons.internal.reflection._Reflect.InterfacePolicy;
 import org.apache.causeway.commons.internal.reflection._Reflect.TypeHierarchyPolicy;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants.ObjectSupportMethod;
@@ -85,7 +86,7 @@ implements ImperativeFacet {
     }
 
     @Getter private final Can<TitleComponent> components;
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     protected TitleFacetViaTitleAnnotation(final Can<TitleComponent> components, final FacetHolder holder) {
         super(holder);
@@ -102,13 +103,14 @@ implements ImperativeFacet {
                     .map(MethodEvaluator.class::cast)
                     .map(MethodEvaluator::getMethod)
                     .findFirst()
+                    .map(_MethodFacades::regular)
                     .map(ImperativeFacet::singleMethod)
                     .orElse(Can.empty())
                 : Can.empty();
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.UI_HINT;
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/title/methods/TitleFacetFromToStringMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/title/methods/TitleFacetFromToStringMethod.java
@@ -49,7 +49,7 @@ implements HasImperativeAspect {
         .filter(method->!ClassExtensions.isJavaClass(method.getDeclaringClass()))
         .map(method->
             new TitleFacetFromToStringMethod(
-                    ImperativeAspect.singleMethod(method, Intent.UI_HINT),
+                    ImperativeAspect.singleRegularMethod(method, Intent.UI_HINT),
                     holder));
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/title/methods/TitleFacetViaTitleMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/title/methods/TitleFacetViaTitleMethod.java
@@ -57,7 +57,7 @@ implements HasImperativeAspect {
         return Optional.ofNullable(methodIfAny)
         .map(method->
             new TitleFacetViaTitleMethod(
-                    ImperativeAspect.singleMethod(method, Intent.UI_HINT),
+                    ImperativeAspect.singleRegularMethod(method, Intent.UI_HINT),
                     TranslationContext.forMethod(method),
                     holder));
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/value/CompositeValueUpdater.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/object/value/CompositeValueUpdater.java
@@ -78,13 +78,14 @@ public abstract class CompositeValueUpdater {
 
     private ManagedObject simpleExecute(
             final InteractionHead head, final Can<ManagedObject> parameters) {
-        val method = delegate.getFacetedMethod().getMethod();
-
         final Object[] executionParameters = MmUnwrapUtil.multipleAsArray(parameters);
         final Object targetPojo = MmUnwrapUtil.single(head.getTarget());
 
+        val methodFacade = delegate.getFacetedMethod().getMethod();
+        val method = methodFacade.asMethodForIntrospection();
+
         val resultPojo = CanonicalInvoker
-                .invoke(method, targetPojo, executionParameters);
+                .invoke(method, targetPojo, methodFacade.getArguments(executionParameters));
 
         return ManagedObject.value(delegate.getReturnType(), resultPojo);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/choices/methodnum/ActionParameterChoicesFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/choices/methodnum/ActionParameterChoicesFacetViaMethod.java
@@ -74,7 +74,7 @@ implements ImperativeFacet {
             final InteractionInitiatedBy interactionInitiatedBy) {
 
         val method = methods.getFirstElseFail();
-        final Object collectionOrArray = MmInvokeUtil.invoke(patConstructor, method, head.getTarget(), pendingArgs);
+        final Object collectionOrArray = MmInvokeUtil.invokeAutofit(patConstructor, method, head.getTarget(), pendingArgs);
         if (collectionOrArray == null) {
             return Can.empty();
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/choices/methodnum/ActionParameterChoicesFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/choices/methodnum/ActionParameterChoicesFacetViaMethod.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants.CollectionSemantics;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
@@ -44,7 +45,7 @@ public class ActionParameterChoicesFacetViaMethod
 extends ActionParameterChoicesFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final TypeOfAnyCardinality paramSupportReturnType;
     private final Optional<Constructor<?>> patConstructor;
 
@@ -55,13 +56,13 @@ implements ImperativeFacet {
             final FacetHolder holder) {
 
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleMethod(method, patConstructor);
         this.paramSupportReturnType = paramSupportReturnType;
         this.patConstructor = patConstructor;
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHOICES_OR_AUTOCOMPLETE;
     }
 
@@ -73,9 +74,7 @@ implements ImperativeFacet {
             final InteractionInitiatedBy interactionInitiatedBy) {
 
         val method = methods.getFirstElseFail();
-        final Object collectionOrArray = patConstructor.isPresent()
-                ? MmInvokeUtil.invokeWithPAT(patConstructor.get(), method, head.getTarget(), pendingArgs)
-                : MmInvokeUtil.invokeAutofit(method, head.getTarget(), pendingArgs);
+        final Object collectionOrArray = MmInvokeUtil.invoke(patConstructor, method, head.getTarget(), pendingArgs);
         if (collectionOrArray == null) {
             return Can.empty();
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/defaults/methodnum/ActionParameterDefaultsFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/defaults/methodnum/ActionParameterDefaultsFacetViaMethod.java
@@ -25,6 +25,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._NullSafe;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.facets.param.defaults.ActionParameterDefaultsFacetAbstract;
@@ -40,7 +41,7 @@ public class ActionParameterDefaultsFacetViaMethod
 extends ActionParameterDefaultsFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final int paramNum;
     private final Optional<Constructor<?>> patConstructor;
 
@@ -57,14 +58,13 @@ implements ImperativeFacet {
             final FacetHolder holder) {
 
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleMethod(method, patConstructor);
         this.paramNum = paramNum;
         this.patConstructor = patConstructor;
     }
 
-
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.DEFAULTS;
     }
 
@@ -79,11 +79,11 @@ implements ImperativeFacet {
         val defaultValue = patConstructor.isPresent()
             // PAT programming model
             ? MmInvokeUtil
-                    .invokeWithPAT(patConstructor.get(), method,
+                    .invokeWithPAT(patConstructor.get(), method.asMethodForIntrospection(),
                             pendingArgs.getActionTarget(), pendingArgs.getParamValues())
             // else support legacy programming model, call any-arg defaultNAct(...)
             : MmInvokeUtil
-                    .invokeAutofit(method,
+                    .invokeAutofit(method.asMethodElseFail(),
                         pendingArgs.getActionTarget(), pendingArgs.getParamValues());
 
         return _NullSafe.streamAutodetect(defaultValue)

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/disable/method/ActionParameterDisabledFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/disable/method/ActionParameterDisabledFacetViaMethod.java
@@ -67,7 +67,7 @@ implements ImperativeFacet {
             final Can<ManagedObject> pendingArgs) {
 
         val method = methods.getFirstElseFail();
-        final Object returnValue = MmInvokeUtil.invoke(patConstructor, method, owningAdapter, pendingArgs);
+        final Object returnValue = MmInvokeUtil.invokeAutofit(patConstructor, method, owningAdapter, pendingArgs);
         if(returnValue instanceof String) {
             return (String) returnValue;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/disable/method/ActionParameterDisabledFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/disable/method/ActionParameterDisabledFacetViaMethod.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import org.apache.causeway.applib.services.i18n.TranslatableString;
 import org.apache.causeway.applib.services.i18n.TranslationContext;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.facets.param.disable.ActionParameterDisabledFacetAbstract;
@@ -40,7 +41,7 @@ public class ActionParameterDisabledFacetViaMethod
 extends ActionParameterDisabledFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final TranslationContext translationContext;
     private final Optional<Constructor<?>> patConstructor;
 
@@ -50,13 +51,13 @@ implements ImperativeFacet {
             final FacetHolder holder) {
 
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleMethod(method, patConstructor);
         this.translationContext = holder.getTranslationContext();
         this.patConstructor = patConstructor;
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHECK_IF_VALID;
     }
 
@@ -66,10 +67,7 @@ implements ImperativeFacet {
             final Can<ManagedObject> pendingArgs) {
 
         val method = methods.getFirstElseFail();
-        final Object returnValue = patConstructor.isPresent()
-                ? MmInvokeUtil.invokeWithPAT(patConstructor.get(), method, owningAdapter, pendingArgs)
-                : MmInvokeUtil.invokeAutofit(method, owningAdapter, pendingArgs);
-
+        final Object returnValue = MmInvokeUtil.invoke(patConstructor, method, owningAdapter, pendingArgs);
         if(returnValue instanceof String) {
             return (String) returnValue;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/hide/method/ActionParameterHiddenFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/hide/method/ActionParameterHiddenFacetViaMethod.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
@@ -39,7 +40,7 @@ public class ActionParameterHiddenFacetViaMethod
 extends ActionParameterHiddenFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final @NonNull Optional<Constructor<?>> patConstructor;
 
     public ActionParameterHiddenFacetViaMethod(
@@ -48,12 +49,12 @@ implements ImperativeFacet {
             final FacetHolder holder) {
 
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleMethod(method, patConstructor);
         this.patConstructor = patConstructor;
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHECK_IF_VALID;
     }
 
@@ -63,10 +64,7 @@ implements ImperativeFacet {
             final Can<ManagedObject> argumentAdapters) {
 
         val method = methods.getFirstElseFail();
-        final Object returnValue = patConstructor.isPresent()
-                ? MmInvokeUtil.invokeWithPAT(patConstructor.get(), method, owningAdapter, argumentAdapters)
-                : MmInvokeUtil.invokeAutofit(method, owningAdapter, argumentAdapters);
-
+        final Object returnValue = MmInvokeUtil.invoke(patConstructor, method, owningAdapter, argumentAdapters);
         if(returnValue instanceof Boolean) {
             return (Boolean) returnValue;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/hide/method/ActionParameterHiddenFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/hide/method/ActionParameterHiddenFacetViaMethod.java
@@ -64,7 +64,7 @@ implements ImperativeFacet {
             final Can<ManagedObject> argumentAdapters) {
 
         val method = methods.getFirstElseFail();
-        final Object returnValue = MmInvokeUtil.invoke(patConstructor, method, owningAdapter, argumentAdapters);
+        final Object returnValue = MmInvokeUtil.invokeAutofit(patConstructor, method, owningAdapter, argumentAdapters);
         if(returnValue instanceof Boolean) {
             return (Boolean) returnValue;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/name/ParameterNameFacetFactoryUsingReflection.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/name/ParameterNameFacetFactoryUsingReflection.java
@@ -55,8 +55,7 @@ extends FacetFactoryAbstract {
     @Override
     public void processParams(final ProcessParameterContext processParameterContext) {
 
-        val parameter = processParameterContext.getParameter();
-        val parameterName = parameter.getName();
+        val parameterName = processParameterContext.getParameterName();
 
         // if not compiled with -parameters flag or synthetic, then ignore
         val argXMatcher = argXPattern.matcher(parameterName);

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/parameter/ParameterAnnotationFacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/parameter/ParameterAnnotationFacetFactory.java
@@ -113,7 +113,7 @@ extends FacetFactoryAbstract {
         val parameterIfAny = processParameterContext.synthesizeOnParameter(Parameter.class);
 
         val parameterAnnotations = MethodParameter
-                .forExecutable(processParameterContext.getMethod(), processParameterContext.getParamNum())
+                .forExecutable(processParameterContext.getMethod().asExecutable(), processParameterContext.getParamNum())
                 .getParameterAnnotations();
         val parameterType = processParameterContext.getParameterType();
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/validate/method/ActionParameterValidationFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/param/validate/method/ActionParameterValidationFacetViaMethod.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import org.apache.causeway.applib.services.i18n.TranslatableString;
 import org.apache.causeway.applib.services.i18n.TranslationContext;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.facets.param.validate.ActionParameterValidationFacetAbstract;
@@ -40,7 +41,7 @@ public class ActionParameterValidationFacetViaMethod
 extends ActionParameterValidationFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final TranslationContext translationContext;
     private final Optional<Constructor<?>> patConstructor;
 
@@ -50,13 +51,13 @@ implements ImperativeFacet {
             final FacetHolder holder) {
 
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleMethod(method, patConstructor);
         this.translationContext = holder.getTranslationContext();
         this.patConstructor = patConstructor;
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHECK_IF_VALID;
     }
 
@@ -68,8 +69,16 @@ implements ImperativeFacet {
 
         val method = methods.getFirstElseFail();
         final Object returnValue = patConstructor.isPresent()
-                ? MmInvokeUtil.invokeWithPAT(patConstructor.get(), method, owningAdapter, pendingArgs)
-                : MmInvokeUtil.invoke(method, owningAdapter, proposedArgument);
+                // provides all pending args as a tuple (for validation)
+                ? MmInvokeUtil.invokeWithPAT(
+                        patConstructor.get(),
+                        method.asMethodForIntrospection(),
+                        owningAdapter, pendingArgs)
+                 // provides only a single pending arg (for validation)
+                : MmInvokeUtil.invoke(
+                        method.asMethodElseFail(),
+                        owningAdapter,
+                        proposedArgument);
 
         if(returnValue instanceof String) {
             return (String) returnValue;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/accessor/PropertyAccessorFacetViaAccessor.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/accessor/PropertyAccessorFacetViaAccessor.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
@@ -40,7 +41,7 @@ extends PropertyOrCollectionAccessorFacetAbstract
 implements ImperativeFacet {
 
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     public PropertyAccessorFacetViaAccessor(
             final ObjectSpecification declaringType,
@@ -48,11 +49,11 @@ implements ImperativeFacet {
             final FacetHolder holder) {
 
         super(declaringType, holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.ACCESSOR;
     }
 
@@ -60,7 +61,7 @@ implements ImperativeFacet {
     public Object getProperty(
             final ManagedObject owningAdapter,
             final InteractionInitiatedBy interactionInitiatedBy) {
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         final Object referencedObject = MmInvokeUtil.invoke(method, owningAdapter);
 
         if(referencedObject == null) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/accessor/PropertyAccessorFacetViaAccessorFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/accessor/PropertyAccessorFacetViaAccessorFactory.java
@@ -50,7 +50,7 @@ extends PropertyOrCollectionIdentifyingFacetFactoryAbstract {
     }
 
     private void attachPropertyAccessFacetForAccessorMethod(final ProcessMethodContext processMethodContext) {
-        final Method accessorMethod = processMethodContext.getMethod();
+        final Method accessorMethod = processMethodContext.getMethod().asMethodElseFail();
         processMethodContext.removeMethod(accessorMethod);
 
         final Class<?> cls = processMethodContext.getCls();

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/autocomplete/method/PropertyAutoCompleteFacetMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/autocomplete/method/PropertyAutoCompleteFacetMethod.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
@@ -39,7 +40,7 @@ public class PropertyAutoCompleteFacetMethod
 extends PropertyAutoCompleteFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final Class<?> choicesClass;
     private final int minLength;
 
@@ -48,13 +49,13 @@ implements ImperativeFacet {
             final Class<?> choicesClass,
             final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
         this.choicesClass = choicesClass;
         this.minLength = MinLengthUtil.determineMinLength(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHOICES_OR_AUTOCOMPLETE;
     }
 
@@ -69,7 +70,7 @@ implements ImperativeFacet {
             final String searchArg,
             final InteractionInitiatedBy interactionInitiatedBy) {
 
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         final Object collectionOrArray = MmInvokeUtil.invoke(method, owningAdapter, searchArg);
         if (collectionOrArray == null) {
             return null;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/choices/method/PropertyChoicesFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/choices/method/PropertyChoicesFacetViaMethod.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.FacetedMethod;
@@ -39,21 +40,20 @@ public class PropertyChoicesFacetViaMethod
 extends PropertyChoicesFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final Class<?> choicesClass;
 
     public PropertyChoicesFacetViaMethod(
             final Method method,
             final Class<?> choicesClass,
             final FacetHolder holder) {
-
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
         this.choicesClass = choicesClass;
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHOICES_OR_AUTOCOMPLETE;
     }
 
@@ -62,7 +62,7 @@ implements ImperativeFacet {
             final ManagedObject owningAdapter,
             final InteractionInitiatedBy interactionInitiatedBy) {
 
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         val elementSpec = ((FacetedMethod) getFacetHolder()).getElementSpecification();
         val optionPojos = MmInvokeUtil.invoke(method, owningAdapter);
         val visibleChoices = ManagedObjects

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/defaults/method/PropertyDefaultFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/defaults/method/PropertyDefaultFacetViaMethod.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.causeway.applib.exceptions.unrecoverable.UnknownTypeException;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.facets.properties.defaults.PropertyDefaultFacetAbstract;
@@ -37,23 +38,23 @@ public class PropertyDefaultFacetViaMethod
 extends PropertyDefaultFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     public PropertyDefaultFacetViaMethod(
             final Method method,
             final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.DEFAULTS;
     }
 
     @Override
     public ManagedObject getDefault(final ManagedObject owningAdapter) {
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         final Object result = MmInvokeUtil.invoke(method, owningAdapter);
         if (result == null) {
             return null;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/property/PropertyAnnotationFacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/property/PropertyAnnotationFacetFactory.java
@@ -327,7 +327,7 @@ extends FacetFactoryAbstract {
 
         addFacetIfPresent(
                 MandatoryFacetInvertedByNullableAnnotationOnProperty
-                .create(hasNullable, method.asMethodElseFail(), holder))
+                .create(hasNullable, method, holder))
         .ifPresent(mandatoryFacet->
                 MetaModelValidatorForConflictingOptionality
                 .flagIfConflict(
@@ -337,7 +337,7 @@ extends FacetFactoryAbstract {
         // search for @Property(optional=...)
         addFacetIfPresent(
                 MandatoryFacetForPropertyAnnotation
-                .create(propertyIfAny, method.asMethodElseFail(), holder))
+                .create(propertyIfAny, method, holder))
         .ifPresent(mandatoryFacet->
                 MetaModelValidatorForConflictingOptionality
                 .flagIfConflict(

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/property/PropertyAnnotationFacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/property/PropertyAnnotationFacetFactory.java
@@ -27,7 +27,6 @@ import org.apache.causeway.applib.annotation.Property;
 import org.apache.causeway.applib.annotation.SemanticsOf;
 import org.apache.causeway.applib.events.domain.PropertyDomainEvent;
 import org.apache.causeway.applib.mixins.system.HasInteractionId;
-import org.apache.causeway.commons.internal.base._NullSafe;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.facetapi.FeatureType;
 import org.apache.causeway.core.metamodel.facets.FacetFactoryAbstract;
@@ -324,15 +323,11 @@ extends FacetFactoryAbstract {
         val holder = processMethodContext.getFacetHolder();
 
         // check for @Nullable
-        val hasNullable =
-                _NullSafe.stream(method.getAnnotations())
-                    .map(annot->annot.annotationType().getSimpleName())
-                    .anyMatch(name->name.equals("Nullable"));
-        //val nullableIfAny = processMethodContext.synthesizeOnMethod(Nullable.class);
+        val hasNullable = method.isAnnotatedAsNullable();
 
         addFacetIfPresent(
                 MandatoryFacetInvertedByNullableAnnotationOnProperty
-                .create(hasNullable, method, holder))
+                .create(hasNullable, method.asMethodElseFail(), holder))
         .ifPresent(mandatoryFacet->
                 MetaModelValidatorForConflictingOptionality
                 .flagIfConflict(
@@ -342,7 +337,7 @@ extends FacetFactoryAbstract {
         // search for @Property(optional=...)
         addFacetIfPresent(
                 MandatoryFacetForPropertyAnnotation
-                .create(propertyIfAny, method, holder))
+                .create(propertyIfAny, method.asMethodElseFail(), holder))
         .ifPresent(mandatoryFacet->
                 MetaModelValidatorForConflictingOptionality
                 .flagIfConflict(

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/property/mandatory/MandatoryFacetForPropertyAnnotation.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/property/mandatory/MandatoryFacetForPropertyAnnotation.java
@@ -18,10 +18,9 @@
  */
 package org.apache.causeway.core.metamodel.facets.properties.property.mandatory;
 
-import java.lang.reflect.Method;
-
 import org.apache.causeway.applib.annotation.Optionality;
 import org.apache.causeway.applib.annotation.Property;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.objectvalue.mandatory.MandatoryFacet;
 import org.apache.causeway.core.metamodel.facets.objectvalue.mandatory.MandatoryFacetAbstract;
@@ -33,7 +32,7 @@ extends MandatoryFacetAbstract {
 
     public static java.util.Optional<MandatoryFacet> create(
             final java.util.Optional<Property> propertyIfAny,
-            final Method method,
+            final MethodFacade method,
             final FacetHolder holder) {
 
         if(!propertyIfAny.isPresent()) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/property/mandatory/MandatoryFacetInvertedByNullableAnnotationOnProperty.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/property/mandatory/MandatoryFacetInvertedByNullableAnnotationOnProperty.java
@@ -18,11 +18,11 @@
  */
 package org.apache.causeway.core.metamodel.facets.properties.property.mandatory;
 
-import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.springframework.lang.Nullable;
 
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.objectvalue.mandatory.MandatoryFacet;
 import org.apache.causeway.core.metamodel.facets.objectvalue.mandatory.MandatoryFacetAbstract;
@@ -41,7 +41,7 @@ extends MandatoryFacetAbstract {
 
     public static Optional<MandatoryFacet> create(
             final boolean hasNullable,
-            final Method method,
+            final MethodFacade method,
             final FacetHolder holder) {
 
         if(!hasNullable) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/PropertySetterFacetFactory.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/PropertySetterFacetFactory.java
@@ -18,8 +18,6 @@
  */
 package org.apache.causeway.core.metamodel.facets.properties.update;
 
-import java.lang.reflect.Method;
-
 import javax.inject.Inject;
 
 import org.apache.causeway.commons.collections.Can;
@@ -53,7 +51,7 @@ extends MethodPrefixBasedFacetFactoryAbstract {
     @Override
     public void process(final ProcessMethodContext processMethodContext) {
 
-        final Method getterMethod = processMethodContext.getMethod();
+        val getterMethod = processMethodContext.getMethod();
         final String capitalizedName = StringExtensions.asJavaBaseName(getterMethod.getName());
         val methodNameCandidates = Can.ofSingleton(
                 AccessorPrefix.SET.prefix(capitalizedName));

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/clear/PropertyClearFacetViaClearMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/clear/PropertyClearFacetViaClearMethod.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
@@ -37,15 +38,15 @@ public class PropertyClearFacetViaClearMethod
 extends PropertyClearFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     public PropertyClearFacetViaClearMethod(final Method method, final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.MODIFY_PROPERTY_SUPPORTING;
     }
 
@@ -54,7 +55,7 @@ implements ImperativeFacet {
             final OneToOneAssociation owningProperty,
             final ManagedObject targetAdapter,
             final InteractionInitiatedBy interactionInitiatedBy) {
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         MmInvokeUtil.invoke(method, targetAdapter);
         return targetAdapter;
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/clear/PropertyClearFacetViaSetterMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/clear/PropertyClearFacetViaSetterMethod.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
@@ -37,15 +38,15 @@ public class PropertyClearFacetViaSetterMethod
 extends PropertyClearFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     public PropertyClearFacetViaSetterMethod(final Method method, final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.MODIFY_PROPERTY;
     }
 
@@ -54,8 +55,7 @@ implements ImperativeFacet {
             final OneToOneAssociation owningProperty,
             final ManagedObject targetAdapter,
             final InteractionInitiatedBy interactionInitiatedBy) {
-
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         MmInvokeUtil.invoke(method, targetAdapter);
         return targetAdapter;
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/init/PropertyInitializationFacetViaSetterMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/init/PropertyInitializationFacetViaSetterMethod.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
@@ -35,15 +36,15 @@ public class PropertyInitializationFacetViaSetterMethod
 extends PropertyInitializationFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     public PropertyInitializationFacetViaSetterMethod(final Method method, final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         // LIMITATION: we cannot distinguish between setXxx being called for a modify or for an initialization
         // so we just assume its a setter.
         return Intent.MODIFY_PROPERTY;
@@ -51,7 +52,7 @@ implements ImperativeFacet {
 
     @Override
     public void initProperty(final ManagedObject owningAdapter, final ManagedObject initialAdapter) {
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         MmInvokeUtil.invoke(method, owningAdapter, initialAdapter);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/modify/PropertySetterFacetViaSetterMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/update/modify/PropertySetterFacetViaSetterMethod.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
@@ -37,15 +38,15 @@ public class PropertySetterFacetViaSetterMethod
 extends PropertySetterFacetAbstract
 implements ImperativeFacet {
 
-    @Getter(onMethod_ = {@Override}) private final @NonNull Can<Method> methods;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
 
     public PropertySetterFacetViaSetterMethod(final Method method, final FacetHolder holder) {
         super(holder);
-        this.methods = ImperativeFacet.singleMethod(method);
+        this.methods = ImperativeFacet.singleRegularMethod(method);
     }
 
     @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.MODIFY_PROPERTY;
     }
 
@@ -56,7 +57,7 @@ implements ImperativeFacet {
             final ManagedObject valueAdapter,
             final InteractionInitiatedBy interactionInitiatedBy) {
 
-        val method = methods.getFirstElseFail();
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         MmInvokeUtil.invoke(method, targetAdapter, valueAdapter);
         return targetAdapter;
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/validating/method/PropertyValidateFacetViaMethod.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/facets/properties/validating/method/PropertyValidateFacetViaMethod.java
@@ -24,41 +24,38 @@ import java.util.function.BiConsumer;
 import org.apache.causeway.applib.services.i18n.TranslatableString;
 import org.apache.causeway.applib.services.i18n.TranslationContext;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.ImperativeFacet;
 import org.apache.causeway.core.metamodel.facets.properties.validating.PropertyValidateFacetAbstract;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.object.MmInvokeUtil;
 
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.val;
+
 public class PropertyValidateFacetViaMethod extends PropertyValidateFacetAbstract implements ImperativeFacet {
 
-    private final Method method;
+    @Getter(onMethod_ = {@Override}) private final @NonNull Can<MethodFacade> methods;
     private final TranslationContext translationContext;
 
     public PropertyValidateFacetViaMethod(
             final Method method,
     		final FacetHolder holder) {
         super(holder);
-        this.method = method;
+        this.methods = ImperativeFacet.singleRegularMethod(method);
         this.translationContext = holder.getTranslationContext();
     }
 
-    /**
-     * Returns a singleton list of the {@link Method} provided in the
-     * constructor.
-     */
     @Override
-    public Can<Method> getMethods() {
-        return Can.ofSingleton(method);
-    }
-
-    @Override
-    public Intent getIntent(final Method method) {
+    public Intent getIntent() {
         return Intent.CHECK_IF_VALID;
     }
 
     @Override
     public String invalidReason(final ManagedObject owningAdapter, final ManagedObject proposedAdapter) {
+        val method = methods.getFirstElseFail().asMethodElseFail(); // expected regular
         final Object returnValue = MmInvokeUtil.invoke(method, owningAdapter, proposedAdapter);
         if(returnValue instanceof String) {
             return (String) returnValue;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/methods/DomainIncludeAnnotationEnforcesMetamodelContributionValidator.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/methods/DomainIncludeAnnotationEnforcesMetamodelContributionValidator.java
@@ -34,6 +34,7 @@ import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.commons.internal.collections._Sets;
 import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.commons.internal.reflection._ClassCache;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.commons.internal.reflection._Reflect;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants.Violation;
 import org.apache.causeway.core.metamodel.commons.MethodUtil;
@@ -87,6 +88,7 @@ extends MetaModelVisitingValidatorAbstract {
         .map(ObjectMemberAbstract.class::cast)
         .map(ObjectMemberAbstract::getFacetedMethod)
         .map(FacetedMethod::getMethod)
+        .map(MethodFacade::asMethodForIntrospection)
         .forEach(memberMethods::add);
 
         spec
@@ -94,6 +96,7 @@ extends MetaModelVisitingValidatorAbstract {
         .map(ObjectMemberAbstract.class::cast)
         .map(ObjectMemberAbstract::getFacetedMethod)
         .map(FacetedMethod::getMethod)
+        .map(MethodFacade::asMethodForIntrospection)
         .forEach(memberMethods::add);
 
         spec

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/methods/DomainIncludeAnnotationEnforcesMetamodelContributionValidator.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/methods/DomainIncludeAnnotationEnforcesMetamodelContributionValidator.java
@@ -108,6 +108,7 @@ extends MetaModelVisitingValidatorAbstract {
         .map(ImperativeFacet.class::cast)
         .map(ImperativeFacet::getMethods)
         .flatMap(Can::stream)
+        .map(MethodFacade::asMethodForIntrospection)
         .forEach(supportMethods::add);
 
         val methodsIntendedToBeIncludedButNotPickedUp = _Sets.<Method>newHashSet();

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/methods/MethodFinderPAT.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/methods/MethodFinderPAT.java
@@ -59,14 +59,13 @@ public final class MethodFinderPAT {
         return finder.streamMethodsIgnoringSignature()
             .filter(MethodUtil.Predicates.paramCount(1 + additionalParamTypes.size()))
             .filter(MethodUtil.Predicates.matchParamTypes(1, additionalParamTypes))
-            .map(method->lookupPatConstructor(finder, method, signature))
+            .map(method->lookupPatConstructor(method, signature))
             .flatMap(Optional::stream);
     }
 
     // -- HELPER
 
     private Optional<MethodAndPatConstructor> lookupPatConstructor(
-            final MethodFinder finder,
             final Method supportingMethod,
             final Class<?>[] signature) {
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/object/MmInvokeUtil.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/object/MmInvokeUtil.java
@@ -65,7 +65,18 @@ public final class MmInvokeUtil {
         CanonicalInvoker.invokeAll(methods, MmUnwrapUtil.single(adapter));
     }
 
-    public static Object invoke(
+    public static Object invokeAutofit(
+            final Optional<Constructor<?>> patConstructor,
+            final MethodFacade methodFacade, final ManagedObject owningAdapter, final Can<ManagedObject> pendingArgs) {
+        return patConstructor.isPresent()
+                ? invokeWithPAT(patConstructor.get(),
+                        methodFacade.asMethodForIntrospection(),
+                        owningAdapter, pendingArgs)
+                : invokeAutofit(methodFacade.asMethodElseFail(),
+                        owningAdapter, pendingArgs);
+    }
+
+    public static Object invokeNoAutofit(
             final Optional<Constructor<?>> patConstructor,
             final MethodFacade methodFacade, final ManagedObject owningAdapter, final Can<ManagedObject> pendingArgs) {
         return patConstructor.isPresent()

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/postprocessors/members/TweakDomainEventsForMixinPostProcessor.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/postprocessors/members/TweakDomainEventsForMixinPostProcessor.java
@@ -91,9 +91,9 @@ extends ObjectSpecificationPostProcessorAbstract {
         if(property instanceof OneToOneAssociationMixedIn) {
             final OneToOneAssociationMixedIn propertyMixin = (OneToOneAssociationMixedIn) property;
             final FacetedMethod facetedMethod = propertyMixin.getFacetedMethod();
-            final Method method = facetedMethod != null ? facetedMethod.getMethod() : null;
+            final Method method = facetedMethod.getMethod().asMethodElseFail(); // no-arg method, should have a regular facade
 
-            if(method != null) {
+            {
                 // this is basically a subset of the code that is in CollectionAnnotationFacetFactory,
                 // ignoring stuff which is deprecated for Causeway v2
 
@@ -132,9 +132,9 @@ extends ObjectSpecificationPostProcessorAbstract {
         if(collection instanceof OneToManyAssociationMixedIn) {
             final OneToManyAssociationMixedIn collectionMixin = (OneToManyAssociationMixedIn) collection;
             final FacetedMethod facetedMethod = collectionMixin.getFacetedMethod();
-            final Method method = facetedMethod != null ? facetedMethod.getMethod() : null;
+            final Method method = facetedMethod.getMethod().asMethodElseFail(); // no-arg method, should have a regular facade
 
-            if(method != null) {
+            {
                 // this is basically a subset of the code that is in CollectionAnnotationFacetFactory,
                 // ignoring stuff which is deprecated for Causeway v2
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/TypeOfAnyCardinality.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/TypeOfAnyCardinality.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import org.springframework.core.ResolvableType;
 
 import org.apache.causeway.commons.internal.assertions._Assert;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.commons.internal.reflection._Reflect.MethodAndImplementingClass;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants.CollectionSemantics;
@@ -88,6 +89,12 @@ public class TypeOfAnyCardinality {
     }
 
     public static TypeOfAnyCardinality forMethodReturn(
+            final Class<?> _implementationClass, final MethodFacade methodFacade) {
+        val _method = methodFacade.asMethodUnsafe(); //FIXME
+        return forMethodReturn(_implementationClass, _method);
+    }
+
+    public static TypeOfAnyCardinality forMethodReturn(
             final Class<?> _implementationClass, final Method _method) {
         val methodReturnGuess = _method.getReturnType();
         return ProgrammingModelConstants.CollectionSemantics.valueOf(methodReturnGuess)
@@ -113,6 +120,12 @@ public class TypeOfAnyCardinality {
             .orElseGet(()->scalar(methodReturn));
         })
         .orElseGet(()->scalar(methodReturnGuess));
+    }
+
+    public static TypeOfAnyCardinality forMethodParameter(
+            final Class<?> _implementationClass, final MethodFacade methodFacade, final int paramIndex) {
+        val _method = methodFacade.asMethodUnsafe(); // FIXME
+        return forMethodParameter(_implementationClass, _method, paramIndex);
     }
 
     public static TypeOfAnyCardinality forMethodParameter(

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/TypeOfAnyCardinality.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/TypeOfAnyCardinality.java
@@ -18,6 +18,7 @@
  */
 package org.apache.causeway.core.metamodel.spec;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
@@ -27,7 +28,9 @@ import java.util.Optional;
 import org.springframework.core.ResolvableType;
 
 import org.apache.causeway.commons.internal.assertions._Assert;
+import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
+import org.apache.causeway.commons.internal.reflection._Reflect.ConstructorAndImplementingClass;
 import org.apache.causeway.commons.internal.reflection._Reflect.MethodAndImplementingClass;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants.CollectionSemantics;
@@ -88,10 +91,9 @@ public class TypeOfAnyCardinality {
                 Optional.of(collectionSemantics));
     }
 
-    public static TypeOfAnyCardinality forMethodReturn(
+    public static TypeOfAnyCardinality forMethodFacadeReturn(
             final Class<?> _implementationClass, final MethodFacade methodFacade) {
-        val _method = methodFacade.asMethodUnsafe(); //FIXME
-        return forMethodReturn(_implementationClass, _method);
+        return forMethodReturn(_implementationClass, methodFacade.asMethodForIntrospection());
     }
 
     public static TypeOfAnyCardinality forMethodReturn(
@@ -122,10 +124,43 @@ public class TypeOfAnyCardinality {
         .orElseGet(()->scalar(methodReturnGuess));
     }
 
-    public static TypeOfAnyCardinality forMethodParameter(
+    public static TypeOfAnyCardinality forMethodFacadeParameter(
             final Class<?> _implementationClass, final MethodFacade methodFacade, final int paramIndex) {
-        val _method = methodFacade.asMethodUnsafe(); // FIXME
-        return forMethodParameter(_implementationClass, _method, paramIndex);
+        val executable = methodFacade.asExecutable();
+        if(executable instanceof Method) {
+            return forMethodParameter(_implementationClass, (Method)executable, paramIndex);
+        } else if(executable instanceof Constructor) {
+            return forConstructorParameter(_implementationClass, (Constructor<?>)executable, paramIndex);
+        }
+        throw _Exceptions.unexpectedCodeReach();
+    }
+
+    public static TypeOfAnyCardinality forConstructorParameter(
+            final Class<?> _implementationClass, final Constructor<?> _constructor, final int paramIndex) {
+        val paramTypeGuess = _constructor.getParameters()[paramIndex].getType();
+        return ProgrammingModelConstants.CollectionSemantics.valueOf(paramTypeGuess)
+        .map(__->{
+            // adopt into default class loader context
+
+            val origin = ConstructorAndImplementingClass.of(_constructor, _implementationClass);
+            val adopted = origin
+                    .adoptIntoDefaultClassLoader()
+                    .getValue()
+                    .orElse(origin);
+
+            val constructor = adopted.getConstructor();
+            val paramType = constructor.getParameters()[paramIndex].getType();
+
+            return ProgrammingModelConstants.CollectionSemantics.valueOf(paramType)
+            .map(collectionSemantics->
+                nonScalar(
+                        adopted.resolveFirstGenericTypeArgumentOnParameter(paramIndex),
+                        paramType,
+                        collectionSemantics)
+            )
+            .orElseGet(()->scalar(paramType));
+        })
+        .orElseGet(()->scalar(paramTypeGuess));
     }
 
     public static TypeOfAnyCardinality forMethodParameter(

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/facetprocessor/FacetProcessor.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/facetprocessor/FacetProcessor.java
@@ -34,6 +34,7 @@ import org.apache.causeway.commons.internal.collections._Maps;
 import org.apache.causeway.commons.internal.collections._Multimaps;
 import org.apache.causeway.commons.internal.collections._Multimaps.ListMultimap;
 import org.apache.causeway.commons.internal.collections._Sets;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.metamodel.context.HasMetaModelContext;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
@@ -329,7 +330,7 @@ implements HasMetaModelContext{
     public void process(
             final Class<?> cls,
             final IntrospectionPolicy introspectionPolicy,
-            final Method method,
+            final MethodFacade method,
             final MethodRemover methodRemover,
             final FacetedMethod facetedMethod,
             final FeatureType featureType,
@@ -372,7 +373,7 @@ implements HasMetaModelContext{
     public void processParams(
             final Class<?> introspectedClass,
             final IntrospectionPolicy introspectionPolicy,
-            final Method method,
+            final MethodFacade method,
             final MethodRemover methodRemover,
             final FacetedMethodParameter facetedMethodParameter) {
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/FacetedMethodsBuilder.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/FacetedMethodsBuilder.java
@@ -376,7 +376,7 @@ implements HasMetaModelContext {
     private FacetedMethod createActionFacetedMethod(
             final Method actionMethod) {
 
-        val actionMethodFacade = _MethodFacades.autodetect(actionMethod);
+        val actionMethodFacade = _MethodFacadeAutodetect.autodetect(actionMethod, inspectedTypeSpec);
 
         if (!isAllParamTypesValid(actionMethodFacade)) {
             return null;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/FacetedMethodsBuilder.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/FacetedMethodsBuilder.java
@@ -248,7 +248,7 @@ implements HasMetaModelContext {
                 log.debug("  identified accessor method representing collection: {}", accessorMethod);
             }
 
-            val accessorMethodFacade = _MethodFacades.autodetect(accessorMethod);
+            val accessorMethodFacade = _MethodFacades.regular(accessorMethod);
 
             // create property and add facets
             val facetedMethod = FacetedMethod.createForCollection(mmc, introspectedClass, accessorMethod);
@@ -294,7 +294,7 @@ implements HasMetaModelContext {
             val facetedMethod = FacetedMethod
                     .createForProperty(getMetaModelContext(), introspectedClass, accessorMethod);
 
-            val accessorMethodFacade = _MethodFacades.autodetect(accessorMethod);
+            val accessorMethodFacade = _MethodFacades.regular(accessorMethod);
 
             // process facets for the 1:1 association (eg. contributed properties)
             getFacetProcessor()

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/FacetedMethodsBuilder.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/FacetedMethodsBuilder.java
@@ -366,21 +366,21 @@ implements HasMetaModelContext {
         // build action (first convert any synthetic method to a regular one)
 
         return _Reflect
-        .lookupRegularMethodForSynthetic(actionMethod)
-        .map(this::createActionFacetedMethod)
-        .filter(_NullSafe::isPresent)
-        .orElse(null);
+            .lookupRegularMethodForSynthetic(actionMethod)
+            .map(this::createActionFacetedMethod)
+            .filter(_NullSafe::isPresent)
+            .orElse(null);
     }
 
     @Nullable
     private FacetedMethod createActionFacetedMethod(
             final Method actionMethod) {
 
-        if (!isAllParamTypesValid(actionMethod)) {
+        val actionMethodFacade = _MethodFacades.autodetect(actionMethod);
+
+        if (!isAllParamTypesValid(actionMethodFacade)) {
             return null;
         }
-
-        val actionMethodFacade = _MethodFacades.autodetect(actionMethod);
 
         final FacetedMethod action = FacetedMethod
                 .createForAction(getMetaModelContext(), introspectedClass, actionMethodFacade);
@@ -406,7 +406,7 @@ implements HasMetaModelContext {
         return action;
     }
 
-    private boolean isAllParamTypesValid(final Method actionMethod) {
+    private boolean isAllParamTypesValid(final MethodFacade actionMethod) {
         for (val paramType : actionMethod.getParameterTypes()) {
             val paramSpec = getSpecificationLoader().loadSpecification(paramType);
             if (paramSpec == null) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectActionDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectActionDefault.java
@@ -34,7 +34,6 @@ import org.apache.causeway.commons.collections.CanVector;
 import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.commons.internal.base._Lazy;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
-import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.core.metamodel.consent.Consent;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.consent.InteractionResultSet;
@@ -531,9 +530,9 @@ implements ObjectAction {
     }
 
     private boolean calculateIsExplicitlyAnnotated() {
-        val javaMethod = getFacetedMethod().getMethod();
-        return _Annotations.synthesize(javaMethod, Action.class).isPresent()
-                || _Annotations.synthesize(javaMethod, ActionLayout.class).isPresent();
+        val methodFacade = getFacetedMethod().getMethod();
+        return methodFacade.synthesize(Action.class).isPresent()
+                || methodFacade.synthesize(ActionLayout.class).isPresent();
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectActionMixedIn.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectActionMixedIn.java
@@ -25,7 +25,6 @@ import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.collections.CanVector;
 import org.apache.causeway.commons.internal.assertions._Assert;
-import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facets.all.named.MemberNamedFacet;
@@ -171,9 +170,9 @@ implements MixedInMember {
     // -- HELPER
 
     private boolean calculateIsExplicitlyAnnotated() {
-        val javaMethod = getFacetedMethod().getMethod();
+        val methodFacade = getFacetedMethod().getMethod();
         return super.isExplicitlyAnnotated() // legacy programming style
-                || _Annotations.synthesize(javaMethod, Domain.Include.class).isPresent();
+                || methodFacade.synthesize(Domain.Include.class).isPresent();
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectActionParameterAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectActionParameterAbstract.java
@@ -77,7 +77,7 @@ implements
         this.paramElementType = paramElementType;
 
         this.javaSourceParamName =
-                objectAction.getFacetedMethod().getMethod().getParameters()[parameterIndex].getName();
+                objectAction.getFacetedMethod().getMethod().getParameterName(parameterIndex);
     }
 
     @Override

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectSpecificationAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectSpecificationAbstract.java
@@ -673,6 +673,10 @@ implements ObjectSpecification {
     public Optional<? extends ObjectMember> getMember(final String memberId) {
         introspectUpTo(IntrospectionState.FULLY_INTROSPECTED);
 
+        if(_Strings.isEmpty(memberId)) {
+            return Optional.empty();
+        }
+        
         val objectAction = getAction(memberId);
         if(objectAction.isPresent()) {
             return objectAction;
@@ -687,6 +691,11 @@ implements ObjectSpecification {
     @Override
     public Optional<ObjectAssociation> getDeclaredAssociation(final String id, final MixedIn mixedIn) {
         introspectUpTo(IntrospectionState.FULLY_INTROSPECTED);
+        
+        if(_Strings.isEmpty(id)) {
+            return Optional.empty();
+        }
+        
         return streamDeclaredAssociations(mixedIn)
                 .filter(objectAssociation->objectAssociation.getId().equals(id))
                 .findFirst();

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToManyAssociationDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToManyAssociationDefault.java
@@ -24,7 +24,6 @@ import org.apache.causeway.applib.annotation.CollectionLayout;
 import org.apache.causeway.applib.annotation.Where;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
-import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.core.metamodel.commons.ToString;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FeatureType;
@@ -189,10 +188,9 @@ implements OneToManyAssociation {
     // -- HELPER
 
     private boolean calculateIsExplicitlyAnnotated() {
-        val javaMethod = getFacetedMethod().getMethod();
-        return _Annotations.synthesize(javaMethod, Collection.class).isPresent()
-                || _Annotations.synthesize(javaMethod, CollectionLayout.class).isPresent();
+        val methodFacade = getFacetedMethod().getMethod();
+        return methodFacade.synthesize(Collection.class).isPresent()
+                || methodFacade.synthesize(CollectionLayout.class).isPresent();
     }
-
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToManyAssociationMixedIn.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToManyAssociationMixedIn.java
@@ -23,7 +23,6 @@ import org.apache.causeway.applib.annotation.Domain;
 import org.apache.causeway.applib.annotation.DomainObject;
 import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.commons.collections.Can;
-import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facetapi.FacetUtil;
@@ -172,9 +171,9 @@ implements MixedInMember {
     // -- HELPER
 
     private boolean calculateIsExplicitlyAnnotated() {
-        val javaMethod = getFacetedMethod().getMethod();
+        val methodFacade = getFacetedMethod().getMethod();
         return super.isExplicitlyAnnotated() // legacy programming style
-                || _Annotations.synthesize(javaMethod, Domain.Include.class).isPresent();
+                || methodFacade.synthesize(Domain.Include.class).isPresent();
     }
 
     private ExecutionPublisher executionPublisher() {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToOneAssociationDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToOneAssociationDefault.java
@@ -26,7 +26,6 @@ import org.apache.causeway.applib.services.command.Command;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._NullSafe;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
-import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.core.metamodel.commons.ToString;
 import org.apache.causeway.core.metamodel.consent.Consent;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
@@ -336,10 +335,9 @@ implements OneToOneAssociation {
     // -- HELPER
 
     private boolean calculateIsExplicitlyAnnotated() {
-        val javaMethod = getFacetedMethod().getMethod();
-        return _Annotations.synthesize(javaMethod, Property.class).isPresent()
-                || _Annotations.synthesize(javaMethod, PropertyLayout.class).isPresent();
+        val methodFacade = getFacetedMethod().getMethod();
+        return methodFacade.synthesize(Property.class).isPresent()
+                || methodFacade.synthesize(PropertyLayout.class).isPresent();
     }
-
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToOneAssociationMixedIn.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToOneAssociationMixedIn.java
@@ -22,7 +22,6 @@ import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.annotation.Domain;
 import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.commons.collections.Can;
-import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facetapi.FacetUtil;
@@ -155,9 +154,9 @@ implements MixedInMember {
     // -- HELPER
 
     private boolean calculateIsExplicitlyAnnotated() {
-        val javaMethod = getFacetedMethod().getMethod();
+        val methodFacade = getFacetedMethod().getMethod();
         return super.isExplicitlyAnnotated() // legacy programming style
-                || _Annotations.synthesize(javaMethod, Domain.Include.class).isPresent();
+                || methodFacade.synthesize(Domain.Include.class).isPresent();
     }
 
     private ExecutionPublisher executionPublisher() {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/_MethodFacadeAutodetect.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/_MethodFacadeAutodetect.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.apache.causeway.applib.annotation.ParameterTuple;
+import org.apache.causeway.applib.annotation.ParameterAsTuple;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.reflection._Annotations;
 import org.apache.causeway.commons.internal.reflection._ClassCache;
@@ -39,12 +39,12 @@ import lombok.experimental.UtilityClass;
 class _MethodFacadeAutodetect {
 
     /**
-     * Detects whether an action uses the {@link ParameterTuple} annotation on its single argument.
+     * Detects whether an action uses the {@link ParameterAsTuple} annotation on its single argument.
      * If so, we follow Parameters as Tuple (PAT) semantics.
      */
     MethodFacade autodetect(final Method method, final FacetHolder inspectedTypeSpec) {
         final long paramTupleCount = Stream.of(method.getParameters())
-            .map(parameter->_Annotations.synthesize(parameter, ParameterTuple.class))
+            .map(parameter->_Annotations.synthesize(parameter, ParameterAsTuple.class))
             .filter(Optional::isPresent)
             .count();
         if(paramTupleCount == 0) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/_MethodFacadeAutodetect.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/_MethodFacadeAutodetect.java
@@ -1,0 +1,79 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.core.metamodel.specloader.specimpl;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.causeway.applib.annotation.ParameterTuple;
+import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.reflection._Annotations;
+import org.apache.causeway.commons.internal.reflection._ClassCache;
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
+import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants.Violation;
+import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
+import org.apache.causeway.core.metamodel.specloader.validator.ValidationFailure;
+
+import lombok.val;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+class _MethodFacadeAutodetect {
+
+    /**
+     * Detects whether an action uses the {@link ParameterTuple} annotation on its single argument.
+     * If so, we follow Parameters as Tuple (PAT) semantics.
+     */
+    MethodFacade autodetect(final Method method, final FacetHolder inspectedTypeSpec) {
+        final long paramTupleCount = Stream.of(method.getParameters())
+            .map(parameter->_Annotations.synthesize(parameter, ParameterTuple.class))
+            .filter(Optional::isPresent)
+            .count();
+        if(paramTupleCount == 0) {
+            return _MethodFacades.regular(method);
+        }
+        if(paramTupleCount > 1
+                || method.getParameterCount() > 1) {
+            // invalid
+            ValidationFailure.raiseFormatted(inspectedTypeSpec,
+                    Violation.PARAMETER_TUPLE_INVALID_USE_OF_ANNOTATION
+                        .builder()
+                        .addVariable("type", inspectedTypeSpec.getFeatureIdentifier().getClassName())
+                        .addVariable("member", method.getName())
+                        .buildMessage());
+        }
+        val patType = method.getParameterTypes()[0];
+        val patConstructors = _ClassCache.getInstance().streamPublicConstructors(patType)
+            .collect(Can.toCan());
+        if(!patConstructors.isCardinalityOne()) {
+            // invalid
+            ValidationFailure.raiseFormatted(inspectedTypeSpec,
+                    Violation.PARAMETER_TUPLE_TYPE_WITH_AMBIGUOUS_CONSTRUCTORS
+                        .builder()
+                        .addVariable("type", inspectedTypeSpec.getFeatureIdentifier().getClassName())
+                        .addVariable("member", method.getName())
+                        .addVariable("patType", patType.getName())
+                        .buildMessage());
+        }
+        return _MethodFacades.paramsAsTuple(method, patConstructors.getFirstElseFail());
+    }
+
+}

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/ObjectSpecificationDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/ObjectSpecificationDefault.java
@@ -36,6 +36,7 @@ import org.apache.causeway.commons.internal.base._Lazy;
 import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.commons.internal.collections._Maps;
 import org.apache.causeway.commons.internal.reflection._Reflect;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.config.beans.CausewayBeanMetaData;
 import org.apache.causeway.core.metamodel.commons.StringExtensions;
 import org.apache.causeway.core.metamodel.commons.ToString;
@@ -287,6 +288,7 @@ implements FacetHolder {
             field.streamFacets(ImperativeFacet.class)
                 .map(ImperativeFacet::getMethods)
                 .flatMap(Can::stream)
+                .map(MethodFacade::asMethodElseFail) // expected regular
                 .forEach(imperativeFacetMethod->onMember.accept(imperativeFacetMethod, field)));
     }
 
@@ -296,8 +298,9 @@ implements FacetHolder {
             userAction.streamFacets(ImperativeFacet.class)
                 .map(ImperativeFacet::getMethods)
                 .flatMap(Can::stream)
+                .map(MethodFacade::asMethodForIntrospection)
                 .forEach(imperativeFacetMethod->
-                onMember.accept(imperativeFacetMethod, userAction)));
+                    onMember.accept(imperativeFacetMethod, userAction)));
     }
 
     /**

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/ObjectSpecificationDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/ObjectSpecificationDefault.java
@@ -33,6 +33,7 @@ import org.apache.causeway.applib.annotation.Introspection.IntrospectionPolicy;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.collections.ImmutableEnumSet;
 import org.apache.causeway.commons.internal.base._Lazy;
+import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.commons.internal.collections._Maps;
 import org.apache.causeway.commons.internal.reflection._Reflect;
@@ -251,8 +252,8 @@ implements FacetHolder {
             final MixedIn mixedIn) {
 
         introspectUpTo(IntrospectionState.FULLY_INTROSPECTED);
-
-        return id == null
+        
+        return _Strings.isEmpty(id)
             ? Optional.empty()
             : streamDeclaredActions(actionScopes, mixedIn)
                 .filter(action->

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facetapi/FeatureTypeTest_identifierFor.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facetapi/FeatureTypeTest_identifierFor.java
@@ -28,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.id.LogicalType;
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
 
 public class FeatureTypeTest_identifierFor {
 
@@ -57,7 +58,7 @@ public class FeatureTypeTest_identifierFor {
     public void property_whenMethodNameIs_XYyyZzz() throws Exception {
         final Method method = SomeDomainClass.class.getMethod("getABigDecimal");
         final Identifier identifierFor = FeatureType.PROPERTY.identifierFor(
-                LogicalType.fqcn(SomeDomainClass.class), method);
+                LogicalType.fqcn(SomeDomainClass.class), _MethodFacades.regular(method));
         assertThat(identifierFor.getMemberLogicalName(), is("ABigDecimal")); // very
         // odd
         // compared
@@ -80,7 +81,7 @@ public class FeatureTypeTest_identifierFor {
     public void property_whenMethodNameIs_XxxxYyyZzz() throws Exception {
         final Method method = SomeDomainClass.class.getMethod("getAnotherBigDecimal");
         final Identifier identifierFor = FeatureType.PROPERTY.identifierFor(
-                LogicalType.fqcn(SomeDomainClass.class), method);
+                LogicalType.fqcn(SomeDomainClass.class), _MethodFacades.regular(method));
         assertThat(identifierFor.getMemberLogicalName(), is("anotherBigDecimal"));
     }
 

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/AbstractFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/AbstractFacetFactoryTest.java
@@ -135,8 +135,8 @@ public abstract class AbstractFacetFactoryTest {
             final String methodName,
             final Class<?>[] signature) {
 
-        facetFactory.processParams(new FacetFactory
-                .ProcessParameterContext(type, IntrospectionPolicy.ANNOTATION_OPTIONAL,
+        facetFactory.processParams(FacetFactory.ProcessParameterContext
+                .forTesting(type, IntrospectionPolicy.ANNOTATION_OPTIONAL,
                         findMethod(type, methodName, signature),
                         null, facetedMethodParameter));
     }

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/actions/ActionMethodsFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/actions/ActionMethodsFacetFactoryTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FeatureType;
 import org.apache.causeway.core.metamodel.facets.AbstractFacetFactoryTest;
@@ -144,7 +145,7 @@ class ActionMethodsFacetFactoryTest extends AbstractFacetFactoryTest {
         final Method default1Method = findMethod(Customer.class, "default1SomeAction", new Class[]{});
 
         final FacetedMethod facetHolderWithParms = FacetedMethod
-                .createForAction(metaModelContext, Customer.class, actionMethod);
+                .createForAction(metaModelContext, Customer.class, _MethodFacades.regular(actionMethod));
 
         facetFactory.process(ProcessMethodContext
                 .forTesting(Customer.class, FeatureType.ACTION, actionMethod, methodRemover, facetHolderWithParms));
@@ -197,7 +198,7 @@ class ActionMethodsFacetFactoryTest extends AbstractFacetFactoryTest {
         final Method choices2Method = findMethod(Customer.class, "choices2SomeAction", new Class[] {});
 
         final FacetedMethod facetHolderWithParms = FacetedMethod.createForAction(
-                metaModelContext, Customer.class, actionMethod);
+                metaModelContext, Customer.class, _MethodFacades.regular(actionMethod));
 
         facetFactory.process(ProcessMethodContext
                 .forTesting(Customer.class, FeatureType.ACTION, actionMethod, methodRemover, facetHolderWithParms));
@@ -247,7 +248,7 @@ class ActionMethodsFacetFactoryTest extends AbstractFacetFactoryTest {
         final Method autoComplete0Method = findMethod(Customer.class, "autoComplete0SomeAction", new Class[] {String.class});
 
         final FacetedMethod facetHolderWithParms = FacetedMethod
-                .createForAction(metaModelContext, Customer.class, actionMethod);
+                .createForAction(metaModelContext, Customer.class, _MethodFacades.regular(actionMethod));
 
         facetFactory.process(ProcessMethodContext
                 .forTesting(Customer.class, FeatureType.ACTION, actionMethod, methodRemover, facetHolderWithParms));

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/actions/action/ActionAnnotationFacetFactoryTest_ActionInvocation.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/actions/action/ActionAnnotationFacetFactoryTest_ActionInvocation.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.causeway.applib.annotation.Action;
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facetapi.FeatureType;
 import org.apache.causeway.core.metamodel.facets.AbstractFacetFactoryTest;
@@ -158,7 +159,7 @@ extends AbstractFacetFactoryTest {
         final Method actionMethod = findMethod(CustomerEx.class, "someAction", new Class[] { int.class, long.class });
 
         final FacetedMethod facetHolderWithParms = FacetedMethod
-                .createForAction(metaModelContext, CustomerEx.class, actionMethod);
+                .createForAction(metaModelContext, CustomerEx.class, _MethodFacades.regular(actionMethod));
 
         processInvocation(facetFactory, ProcessMethodContext
                 .forTesting(CustomerEx.class, null, actionMethod, methodRemover, facetHolderWithParms));
@@ -205,7 +206,8 @@ extends AbstractFacetFactoryTest {
         final Method choices1Method = findMethod(CustomerEx.class, "choices1SomeAction", new Class[] {});
         final Method disableMethod = findMethod(CustomerEx.class, "disableSomeAction", new Class[] {});
 
-        final FacetedMethod facetHolderWithParms = FacetedMethod.createForAction(metaModelContext, CustomerEx.class, actionMethod);
+        final FacetedMethod facetHolderWithParms = FacetedMethod.createForAction(metaModelContext, CustomerEx.class,
+                _MethodFacades.regular(actionMethod));
 
         final ProcessMethodContext processMethodContext = ProcessMethodContext
                 .forTesting(CustomerEx.class, FeatureType.ACTION, actionMethod, methodRemover, facetHolderWithParms);

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/actions/notinservicemenu/derived/NotInServiceMenuFacetFromDomainServiceFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/actions/notinservicemenu/derived/NotInServiceMenuFacetFromDomainServiceFacetFactoryTest.java
@@ -68,7 +68,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
         // when
         facetFactory.process(ProcessMethodContext
-                .forTesting(CustomerService.class, null, facetedMethod.getMethod(), mockMethodRemover, facetedMethod));
+                .forTesting(CustomerService.class, null, facetedMethod.getMethod().asMethod().orElseThrow(), mockMethodRemover, facetedMethod));
 
         // then
         final Facet facet = facetedMethod.lookupNonFallbackFacet(NotInServiceMenuFacet.class).orElse(null);
@@ -97,7 +97,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
         // when
         facetFactory.process(ProcessMethodContext
-                .forTesting(CustomerService.class, null, facetedMethod.getMethod(), mockMethodRemover, facetedMethod));
+                .forTesting(CustomerService.class, null, facetedMethod.getMethod().asMethod().orElseThrow(), mockMethodRemover, facetedMethod));
 
         // then
         final Facet facet = facetedMethod.lookupNonFallbackFacet(NotInServiceMenuFacet.class).orElse(null);
@@ -123,7 +123,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
         // when
         facetFactory.process(ProcessMethodContext
-                .forTesting(CustomerService.class, null, facetedMethod.getMethod(), mockMethodRemover, facetedMethod));
+                .forTesting(CustomerService.class, null, facetedMethod.getMethod().asMethod().orElseThrow(), mockMethodRemover, facetedMethod));
 
         // then
         final Facet facet = facetedMethod.lookupNonFallbackFacet(NotInServiceMenuFacet.class).orElse(null);
@@ -148,7 +148,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
         // when
         facetFactory.process(ProcessMethodContext
-                .forTesting(CustomerService.class, null, facetedMethod.getMethod(), mockMethodRemover, facetedMethod));
+                .forTesting(CustomerService.class, null, facetedMethod.getMethod().asMethod().orElseThrow(), mockMethodRemover, facetedMethod));
 
         // then
         final Facet facet = facetedMethod.lookupNonFallbackFacet(NotInServiceMenuFacet.class).orElse(null);

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/object/callback/CallbackFacetFactoryTestAbstract.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/object/callback/CallbackFacetFactoryTestAbstract.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants;
 import org.apache.causeway.core.metamodel.facets.AbstractFacetFactoryTest;
 import org.apache.causeway.core.metamodel.facets.FacetFactory;
@@ -62,7 +63,8 @@ extends AbstractFacetFactoryTest {
                 .forTesting(type, methodRemover, facetedMethod));
 
         val callbackMethods = callbackMethod.getMethodNames()
-                .map(methodName->findMethod(type, methodName));
+                .map(methodName->findMethod(type, methodName))
+                .map(_MethodFacades::regular);
 
         Assertions.assertEquals(expectedCallbackCount, callbackMethods.size());
 

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/object/mixin/MixinIntendedAs.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/object/mixin/MixinIntendedAs.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.annotation.Introspection.IntrospectionPolicy;
 import org.apache.causeway.applib.id.LogicalType;
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
 import org.apache.causeway.core.metamodel._testing.MetaModelContext_forTesting;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facetapi.FeatureType;
@@ -84,11 +85,11 @@ abstract class MixinIntendedAs {
                 metaModelContext,
                 FeatureType.ACTION_PARAMETER_SINGULAR,
                 owningType,
-                actionMethod,
+                _MethodFacades.regular(actionMethod),
                 0);
 
         val processParameterContext =
-                new ProcessParameterContext(
+                ProcessParameterContext.forTesting(
                         owningType,
                         IntrospectionPolicy.ANNOTATION_OPTIONAL,
                         actionMethod,

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/object/support/ObjectSupportFacetFactoryTestAbstract.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/object/support/ObjectSupportFacetFactoryTestAbstract.java
@@ -18,11 +18,11 @@
  */
 package org.apache.causeway.core.metamodel.facets.object.support;
 
-import org.junit.jupiter.api.Assertions;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.causeway.commons.internal.reflection._MethodFacades;
 import org.apache.causeway.core.config.progmodel.ProgrammingModelConstants;
 import org.apache.causeway.core.metamodel.facetapi.Facet;
 import org.apache.causeway.core.metamodel.facets.AbstractFacetFactoryTest;
@@ -61,9 +61,10 @@ extends AbstractFacetFactoryTest {
                 .forTesting(type, methodRemover, facetedMethod));
 
         val supportMethods = supportMethodEnum.getMethodNames()
-                .map(methodName->findMethod(type, methodName));
+                .map(methodName->findMethod(type, methodName))
+                .map(_MethodFacades::regular);
 
-        Assertions.assertEquals(expectedSupportMethodCount, supportMethods.size());
+        assertEquals(expectedSupportMethodCount, supportMethods.size());
 
         val facet = facetedMethod.getFacet(facetType);
         assertNotNull(facet);

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/layout/annotation/LabelAtFacetForParameterLayoutAnnotationFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/layout/annotation/LabelAtFacetForParameterLayoutAnnotationFactoryTest.java
@@ -47,7 +47,7 @@ public class LabelAtFacetForParameterLayoutAnnotationFactoryTest extends Abstrac
         }
         final Method method = findMethod(Customer.class, "someAction", new Class[] { String.class });
 
-        facetFactory.processParams(new FacetFactory.ProcessParameterContext(
+        facetFactory.processParams(FacetFactory.ProcessParameterContext.forTesting(
                 Customer.class,
                 IntrospectionPolicy.ANNOTATION_OPTIONAL,
                 method, null, facetedMethodParameter));

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/layout/annotation/NamedFacetForParameterLayoutAnnotationFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/layout/annotation/NamedFacetForParameterLayoutAnnotationFactoryTest.java
@@ -51,7 +51,7 @@ extends AbstractFacetFactoryTest {
         }
         final Method method = findMethod(Customer.class, "someAction", new Class[]{String.class});
 
-        facetFactory.processParams(new FacetFactory.ProcessParameterContext(
+        facetFactory.processParams(FacetFactory.ProcessParameterContext.forTesting(
                 Customer.class,
                 IntrospectionPolicy.ANNOTATION_OPTIONAL,
                 method, null, facetedMethodParameter));

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/name/ParameterNameFacetTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/name/ParameterNameFacetTest.java
@@ -99,7 +99,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
         // when
         val processParameterContext =
-                new FacetFactory.ProcessParameterContext(
+                FacetFactory.ProcessParameterContext.forTesting(
                         Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
 
         programmingModel.streamFactories()
@@ -131,7 +131,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
         // when
         val processParameterContext =
-                new FacetFactory.ProcessParameterContext(
+                FacetFactory.ProcessParameterContext.forTesting(
                         Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
         programmingModel.streamFactories().forEach(facetFactory->facetFactory.processParams(processParameterContext));
 

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/parameter/ParameterAnnotationFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/parameter/ParameterAnnotationFacetFactoryTest.java
@@ -95,7 +95,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -142,7 +142,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -180,7 +180,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -208,7 +208,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -236,7 +236,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -260,7 +260,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -293,7 +293,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -323,7 +323,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -350,7 +350,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 
@@ -378,7 +378,7 @@ extends AbstractFacetFactoryJupiterTestCase {
 
             // when
             final FacetFactory.ProcessParameterContext processParameterContext =
-                    new FacetFactory.ProcessParameterContext(
+                    FacetFactory.ProcessParameterContext.forTesting(
                             Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, actionMethod, null, facetedMethodParameter);
             facetFactory.processParams(processParameterContext);
 

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/parameter/ParameterOptionalityOrNullableAnnotationOnParameterFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/parameter/ParameterOptionalityOrNullableAnnotationOnParameterFacetFactoryTest.java
@@ -56,7 +56,7 @@ class ParameterOptionalityOrNullableAnnotationOnParameterFacetFactoryTest extend
         final Method method = findMethod(Customer.class, "someAction", new Class[] { String.class });
 
         facetFactory.processParamsOptional(
-                new ProcessParameterContext(
+                ProcessParameterContext.forTesting(
                         Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, method, null, facetedMethodParameter));
 
         final Facet facet = facetedMethodParameter.getFacet(MandatoryFacet.class);
@@ -74,7 +74,7 @@ class ParameterOptionalityOrNullableAnnotationOnParameterFacetFactoryTest extend
         final Method method = findMethod(Customer.class, "someAction", new Class[] { int.class });
 
         facetFactory.processParamsOptional(
-                new ProcessParameterContext(
+                ProcessParameterContext.forTesting(
                         Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, method, null, facetedMethodParameter));
 
         assertNull(facetedMethod.getFacet(MandatoryFacet.class));
@@ -90,7 +90,7 @@ class ParameterOptionalityOrNullableAnnotationOnParameterFacetFactoryTest extend
         final Method method = findMethod(Customer.class, "someAction", new Class[] { String.class });
 
         facetFactory.processParamsOptional(
-                new ProcessParameterContext(
+                ProcessParameterContext.forTesting(
                         Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, method, null, facetedMethodParameter));
 
         final Facet facet = facetedMethodParameter.getFacet(MandatoryFacet.class);
@@ -108,7 +108,7 @@ class ParameterOptionalityOrNullableAnnotationOnParameterFacetFactoryTest extend
         final Method method = findMethod(Customer.class, "someAction", new Class[] { int.class });
 
         facetFactory.processParamsOptional(
-                new ProcessParameterContext(
+                ProcessParameterContext.forTesting(
                         Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, method, null, facetedMethodParameter));
 
         assertNull(facetedMethod.getFacet(MandatoryFacet.class));

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/parameter/RegExAnnotationOnParameterFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/param/parameter/RegExAnnotationOnParameterFacetFactoryTest.java
@@ -57,7 +57,7 @@ class RegExAnnotationOnParameterFacetFactoryTest extends AbstractFacetFactoryTes
         final Method method = findMethod(Customer.class, "someAction", new Class[] { String.class });
 
         facetFactory.processParams(
-                new ProcessParameterContext(
+                ProcessParameterContext.forTesting(
                         Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, method, null, facetedMethodParameter));
 
         final Facet facet = facetedMethodParameter.getFacet(RegExFacet.class);
@@ -78,7 +78,7 @@ class RegExAnnotationOnParameterFacetFactoryTest extends AbstractFacetFactoryTes
         final Method method = findMethod(Customer.class, "someAction", new Class[] { int.class });
 
         facetFactory.processParams(
-                new ProcessParameterContext(
+                ProcessParameterContext.forTesting(
                         Customer.class, IntrospectionPolicy.ANNOTATION_OPTIONAL, method, null, facetedMethodParameter));
 
         assertNull(facetedMethod.getFacet(RegExFacet.class));

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/executor/MemberExecutorServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/executor/MemberExecutorServiceDefault.java
@@ -44,6 +44,7 @@ import org.apache.causeway.commons.functional.Try;
 import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
+import org.apache.causeway.commons.internal.reflection._MethodFacades.MethodFacade;
 import org.apache.causeway.core.config.CausewayConfiguration;
 import org.apache.causeway.core.metamodel.commons.CanonicalInvoker;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
@@ -116,7 +117,7 @@ implements MemberExecutorService {
             final @NonNull InteractionHead head,
             final @NonNull Can<ManagedObject> argumentAdapters,
             final @NonNull InteractionInitiatedBy interactionInitiatedBy,
-            final @NonNull Method method,
+            final @NonNull MethodFacade methodFacade,
             final @NonNull ActionExecutorFactory actionExecutorFactory,
             final @NonNull FacetHolder facetHolder) {
 
@@ -129,7 +130,7 @@ implements MemberExecutorService {
         }});
 
         if(interactionInitiatedBy.isPassThrough()) {
-            val resultPojo = invokeMethodPassThrough(method, head, argumentAdapters);
+            val resultPojo = invokeMethodPassThrough(methodFacade, head, argumentAdapters);
             return facetHolder.getObjectManager().adapt(resultPojo);
         }
 
@@ -189,7 +190,7 @@ implements MemberExecutorService {
             executionPublisher().publishActionInvocation(priorExecution);
         }
 
-        val result = resultFilteredHonoringVisibility(method, returnedAdapter, interactionInitiatedBy);
+        val result = resultFilteredHonoringVisibility(returnedAdapter, interactionInitiatedBy);
         _Xray.exitInvocation(xrayHandle);
         return result;
     }
@@ -256,13 +257,13 @@ implements MemberExecutorService {
 
     @SneakyThrows
     private Object invokeMethodPassThrough(
-            final Method method,
+            final MethodFacade methodFacade,
             final InteractionHead head,
             final Can<ManagedObject> arguments) {
 
         final Object[] executionParameters = MmUnwrapUtil.multipleAsArray(arguments);
         final Object targetPojo = MmUnwrapUtil.single(head.getTarget());
-        return CanonicalInvoker.invoke(method, targetPojo, executionParameters);
+        return CanonicalInvoker.invoke(methodFacade, targetPojo, executionParameters);
     }
 
     private void setCommandResultIfEntity(
@@ -295,7 +296,6 @@ implements MemberExecutorService {
     }
 
     private ManagedObject resultFilteredHonoringVisibility(
-            final Method method,
             final ManagedObject resultAdapter,
             final InteractionInitiatedBy interactionInitiatedBy) {
 

--- a/regressiontests/stable-interact/src/test/java/org/apache/causeway/testdomain/interact/NewParameterModelTest.java
+++ b/regressiontests/stable-interact/src/test/java/org/apache/causeway/testdomain/interact/NewParameterModelTest.java
@@ -21,6 +21,8 @@ package org.apache.causeway.testdomain.interact;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
@@ -69,10 +71,11 @@ class NewParameterModelTest extends InteractionTestAbstract {
         assertMetamodelValid();
     }
 
-    @Test
-    void paramAnnotations_whenNpm_shouldBeRecognized() {
+    @ParameterizedTest
+    @ValueSource(strings = {"biArgEnabled", "patEnabled"})
+    void paramAnnotations_whenNpm_shouldBeRecognized(final String mixinName) {
 
-        val param0Metamodel = startActionInteractionOn(InteractionNpmDemo.class, "biArgEnabled", Where.OBJECT_FORMS)
+        val param0Metamodel = startActionInteractionOn(InteractionNpmDemo.class, mixinName, Where.OBJECT_FORMS)
                 .getMetamodel().get().getParameters().getElseFail(0);
 
         // as with first param's @Parameter(maxLength = 2)
@@ -163,10 +166,11 @@ class NewParameterModelTest extends InteractionTestAbstract {
         assertComponentWiseEquals(expectedDefaults, actualDefaults);
     }
 
-    @Test
-    void actionInteraction_shouldProvideChoices() {
+    @ParameterizedTest
+    @ValueSource(strings = {"biArgEnabled", "patEnabled"})
+    void actionInteraction_shouldProvideChoices(final String mixinName) {
 
-        val actionInteraction = startActionInteractionOn(InteractionNpmDemo.class, "biArgEnabled", Where.OBJECT_FORMS)
+        val actionInteraction = startActionInteractionOn(InteractionNpmDemo.class, mixinName, Where.OBJECT_FORMS)
                 .checkVisibility()
                 .checkUsability();
 
@@ -184,6 +188,7 @@ class NewParameterModelTest extends InteractionTestAbstract {
         val actualChoices = param1Choices.getValue();
 
         assertComponentWiseUnwrappedEquals(expectedChoices, actualChoices);
+        
     }
 
 

--- a/regressiontests/stable/src/main/java/org/apache/causeway/testdomain/model/interaction/InteractionNpmDemo_patEnabled.java
+++ b/regressiontests/stable/src/main/java/org/apache/causeway/testdomain/model/interaction/InteractionNpmDemo_patEnabled.java
@@ -1,0 +1,71 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.testdomain.model.interaction;
+
+import org.apache.causeway.applib.annotation.Action;
+import org.apache.causeway.applib.annotation.MemberSupport;
+import org.apache.causeway.applib.annotation.Parameter;
+import org.apache.causeway.applib.annotation.ParameterLayout;
+import org.apache.causeway.applib.annotation.ParameterAsTuple;
+
+import lombok.RequiredArgsConstructor;
+
+@Action
+@RequiredArgsConstructor
+public class InteractionNpmDemo_patEnabled {
+
+    @SuppressWarnings("unused")
+    private final InteractionNpmDemo holder;
+
+    /**
+     * Parameters as Tuple (PAT) example. 
+     * However, using Java records is the recommended way, once available.
+     */
+    public static class Params {
+        private final int a;
+        private final int b;
+
+        public Params(
+                @Parameter(maxLength = 2) // setup so we can test for this facet
+                @ParameterLayout(describedAs = "first") // setup so we can test for this facet
+                final int a,
+                final int b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    @MemberSupport public int act(final @ParameterAsTuple Params p) {
+        return p.a + p.b;
+    }
+
+    // -- PARAM 0
+
+    // [CAUSEWAY-2362] parameter supporting methods, to be referenced by param name
+    @MemberSupport public int defaultA(Params params) {
+        return 5;
+    }
+
+    // -- PARAM 1
+
+    // [CAUSEWAY-2362] parameter supporting methods, to be referenced by param name
+    @MemberSupport public int[] choicesB(Params params) {
+        return new int[] {1, 2, 3, 4};
+    }
+}


### PR DESCRIPTION
provide all the prerequisites in `master` to make **java records** PAT support a thing in `spring6` branch
- [x] abstraction layer on top of `java.reflect.Method`
- [x] `TypeOfAnyCardinality` to support constructor introspection as well
- [x] remove `MethodFacade.unsafe(...)` as originating from an intermediate refactoring step
- [x] provide a test case, using a regular java class (@lombok.Value) style, to simulate how that would look like later on with record types instead
