### PR TITLE
CAUSEWAY-3578: Support for plurals in table cells

### DIFF
--- a/api/applib/src/main/java/org/apache/causeway/applib/services/placeholder/PlaceholderRenderService.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/placeholder/PlaceholderRenderService.java
@@ -18,6 +18,12 @@
  */
 package org.apache.causeway.applib.services.placeholder;
 
+import java.util.Map;
+
+import org.springframework.lang.Nullable;
+
+import org.apache.causeway.commons.internal.base._StringInterpolation;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +39,9 @@ public interface PlaceholderRenderService {
     @RequiredArgsConstructor
     public static enum PlaceholderLiteral {
         NULL_REPRESENTATION("none"),
-        SUPPRESSED("suppressed");
+        SUPPRESSED("suppressed"),
+        HAS_MORE("has ${number} more");
+        ;
         private final String literal;
     }
 
@@ -41,20 +49,39 @@ public interface PlaceholderRenderService {
      * Textual representation of given {@link PlaceholderLiteral},
      * as used for eg. titles and choice drop-downs.
      */
-    String asText(@NonNull PlaceholderLiteral placeholderLiteral);
+    String asText(@NonNull PlaceholderLiteral placeholderLiteral, @Nullable Map<String, String> vars);
+    default String asText(@NonNull final PlaceholderLiteral placeholderLiteral) {
+        return asText(placeholderLiteral, null);
+    }
 
     /**
-     * Html representation of given {@link PlaceholderLiteral},
+     * HTML representation of given {@link PlaceholderLiteral},
      * as used for rendering with the UI (when appropriate).
      */
-    String asHtml(@NonNull PlaceholderLiteral placeholderLiteral);
+    String asHtml(@NonNull PlaceholderLiteral placeholderLiteral, @Nullable Map<String, String> vars);
+    default String asHtml(@NonNull final PlaceholderLiteral placeholderLiteral) {
+        return asHtml(placeholderLiteral, null);
+    }
+
+    static String interpolate(final String raw, @Nullable final Map<String, String> vars) {
+        return vars!=null
+                ? new _StringInterpolation(vars).applyTo(raw)
+                : raw;
+    }
 
     static PlaceholderRenderService fallback() {
         return new PlaceholderRenderService() {
-            @Override public String asText(@NonNull final PlaceholderLiteral placeholderLiteral) {
-                return "(" + placeholderLiteral.getLiteral() + ")"; }
-            @Override public String asHtml(@NonNull final PlaceholderLiteral placeholderLiteral) {
-                return asText(placeholderLiteral); }
+            @Override public String asText(
+                    @NonNull final PlaceholderLiteral placeholderLiteral,
+                    @Nullable final Map<String, String> vars) {
+                return PlaceholderRenderService.interpolate(placeholderLiteral.getLiteral(), vars);
+            }
+
+            @Override public String asHtml(
+                    @NonNull final PlaceholderLiteral placeholderLiteral,
+                    @Nullable final Map<String, String> vars) {
+                return asText(placeholderLiteral, vars);
+            }
         };
     }
 

--- a/api/applib/src/test/java/org/apache/causeway/applib/value/Password_Test.java
+++ b/api/applib/src/test/java/org/apache/causeway/applib/value/Password_Test.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.causeway.applib.services.placeholder.PlaceholderRenderService.PlaceholderLiteral;
+
 import lombok.val;
 
 class Password_Test {
@@ -73,10 +75,10 @@ class Password_Test {
         @Test
         void obscures_password() {
             Password password = new Password("secret");
-            assertEquals("(suppressed)", password.toString());
+            assertEquals(PlaceholderLiteral.SUPPRESSED.getLiteral(), password.toString());
 
             password = new Password("a very very very long password");
-            assertEquals("(suppressed)", password.toString());
+            assertEquals(PlaceholderLiteral.SUPPRESSED.getLiteral(), password.toString());
         }
     }
 

--- a/commons/src/main/java/org/apache/causeway/commons/internal/html/_BootstrapBadge.java
+++ b/commons/src/main/java/org/apache/causeway/commons/internal/html/_BootstrapBadge.java
@@ -42,18 +42,32 @@ public class _BootstrapBadge {
 
     final String caption;
     final String faIcon;
+    final String href;
     final String tooltip;
+    final String nestedCaption;
 
     @Singular
     final List<String> cssClasses;
 
     public String toHtml() {
+        return _Strings.isNotEmpty(getHref())
+                ? link()
+                : noLink();
+    }
+
+    // -- HELPER
+
+    /*
+     * // no href
+     * <span class="badge bg-light placeholder-literal-xxx">[none]</span>
+     */
+    public String noLink() {
 
         val sb = new StringBuilder();
         sb
         .append("<span ")
         .append("class=\"")
-        .append(classesLiteral())
+        .append(classesLiteral("badge", "bg-light"))
         .append("\"");
 
         // optional tooltip
@@ -76,13 +90,49 @@ public class _BootstrapBadge {
         sb
         .append(getCaption())
         .append("</span>");
+
         return sb.toString();
     }
 
-    // -- HELPER
+    /*
+     * // with href
+     * <a class="btn btn-sm btn-light placeholder-literal-xxx" href="https://www.example.org" target="_blank">
+     *      has more ... <span class="badge text-sm text-bg-secondary">4</span>
+     * </a>
+     */
+    public String link() {
 
-    private String classesLiteral() {
-        return Stream.concat(Stream.of("badge", "bg-light"), _NullSafe.stream(cssClasses))
+        val sb = new StringBuilder();
+        sb
+        .append("<a ")
+        .append("class=\"")
+        .append(classesLiteral("btn", "btn-sm", "bg-light"))
+        .append("\"")
+        .append(" href=\"")
+        .append(getHref())
+        .append("\"")
+        .append(" target=\"")
+        .append("_blank")
+        .append("\"");
+
+        sb.append(">"); // end a open tag
+
+        sb
+        .append(getCaption());
+
+        // optional nested badge
+        if(_Strings.isNotEmpty(getNestedCaption())) {
+            sb.append(String.format(" <span class=\"badge text-sm text-bg-secondary\">%s</span>", getNestedCaption()));
+        }
+
+        sb
+        .append("</a>");
+
+        return sb.toString();
+    }
+
+    private String classesLiteral(final String ... primaryClasses) {
+        return Stream.concat(_NullSafe.stream(primaryClasses), _NullSafe.stream(cssClasses))
                 .collect(Collectors.joining(" "));
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataColumn.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataColumn.java
@@ -29,12 +29,14 @@ import lombok.NonNull;
 
 public class DataColumn {
 
+    @Getter private final @NonNull String columnId;
     @Getter private final @NonNull ObjectAssociation associationMetaModel;
     @Getter private final @NonNull LazyObservable<String> columnFriendlyName;
     @Getter private final @NonNull LazyObservable<Optional<String>> columnDescription;
 
     public DataColumn(final DataTableModel parentTable, final ObjectAssociation associationMetaModel) {
         this.associationMetaModel = associationMetaModel;
+        this.columnId = associationMetaModel.getId(); //TODO[CAUSEWAY-3578] can we rule out memberId clashes?
 
         columnFriendlyName = _Observables.lazy(()->
             associationMetaModel.getCanonicalFriendlyName());

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataColumn.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataColumn.java
@@ -36,7 +36,7 @@ public class DataColumn {
 
     public DataColumn(final DataTableModel parentTable, final ObjectAssociation associationMetaModel) {
         this.associationMetaModel = associationMetaModel;
-        this.columnId = associationMetaModel.getId(); //TODO[CAUSEWAY-3578] can we rule out memberId clashes?
+        this.columnId = associationMetaModel.getId();
 
         columnFriendlyName = _Observables.lazy(()->
             associationMetaModel.getCanonicalFriendlyName());

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataColumn.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataColumn.java
@@ -22,26 +22,25 @@ import java.util.Optional;
 
 import org.apache.causeway.commons.internal.binding._Observables;
 import org.apache.causeway.commons.internal.binding._Observables.LazyObservable;
-import org.apache.causeway.core.metamodel.spec.feature.OneToOneAssociation;
+import org.apache.causeway.core.metamodel.spec.feature.ObjectAssociation;
 
 import lombok.Getter;
 import lombok.NonNull;
 
 public class DataColumn {
 
-    @Getter private final @NonNull OneToOneAssociation propertyMetaModel;
+    @Getter private final @NonNull ObjectAssociation associationMetaModel;
     @Getter private final @NonNull LazyObservable<String> columnFriendlyName;
     @Getter private final @NonNull LazyObservable<Optional<String>> columnDescription;
 
-    public DataColumn(final DataTableModel parentTable, final OneToOneAssociation propertyMetaModel) {
-        this.propertyMetaModel = propertyMetaModel;
+    public DataColumn(final DataTableModel parentTable, final ObjectAssociation associationMetaModel) {
+        this.associationMetaModel = associationMetaModel;
 
         columnFriendlyName = _Observables.lazy(()->
-            propertyMetaModel.getCanonicalFriendlyName());
+            associationMetaModel.getCanonicalFriendlyName());
 
         columnDescription = _Observables.lazy(()->
-            propertyMetaModel.getCanonicalDescription());
-
+            associationMetaModel.getCanonicalDescription());
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataRow.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataRow.java
@@ -24,6 +24,7 @@ import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.binding._Bindables;
 import org.apache.causeway.commons.internal.binding._Bindables.BooleanBindable;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
+import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.core.metamodel.spec.feature.ObjectAssociation;
 
 import lombok.Getter;
@@ -68,7 +69,7 @@ public class DataRow {
         final ObjectAssociation assoc = column.getAssociationMetaModel();
         return assoc.getSpecialization().fold(
                 property->Can.of(property.get(getRowElement())),
-                collection->Can.of(collection.get(getRowElement())));
+                collection->ManagedObjects.unpack(collection.get(getRowElement())));
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataRow.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataRow.java
@@ -20,9 +20,11 @@ package org.apache.causeway.core.metamodel.interactions.managed.nonscalar;
 
 import java.util.UUID;
 
+import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.binding._Bindables;
 import org.apache.causeway.commons.internal.binding._Bindables.BooleanBindable;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
+import org.apache.causeway.core.metamodel.spec.feature.ObjectAssociation;
 
 import lombok.Getter;
 import lombok.NonNull;
@@ -59,8 +61,14 @@ public class DataRow {
         return rowElement;
     }
 
-    public ManagedObject getCellElement(final @NonNull DataColumn column) {
-        return column.getPropertyMetaModel().get(getRowElement());
+    /**
+     * Can be none, one or many per table cell.
+     */
+    public Can<ManagedObject> getCellElementsForColumn(final @NonNull DataColumn column) {
+        final ObjectAssociation assoc = column.getAssociationMetaModel();
+        return assoc.getSpecialization().fold(
+                property->Can.of(property.get(getRowElement())),
+                collection->Can.of(collection.get(getRowElement())));
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataRow.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataRow.java
@@ -18,6 +18,7 @@
  */
 package org.apache.causeway.core.metamodel.interactions.managed.nonscalar;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.causeway.commons.collections.Can;
@@ -62,6 +63,12 @@ public class DataRow {
         return rowElement;
     }
 
+    public Optional<DataColumn> lookupColumnById(final @NonNull String columnId) {
+        return parentTable.getDataColumns().getValue().stream()
+                .filter(dataColumn->dataColumn.getColumnId().equals(columnId))
+                .findFirst();
+    }
+
     /**
      * Can be none, one or many per table cell.
      */
@@ -70,6 +77,15 @@ public class DataRow {
         return assoc.getSpecialization().fold(
                 property->Can.of(property.get(getRowElement())),
                 collection->ManagedObjects.unpack(collection.get(getRowElement())));
+    }
+
+    /**
+     * Can be none, one or many per table cell. (returns empty Can if column not found)
+     */
+    public Can<ManagedObject> getCellElementsForColumn(final @NonNull String columnId) {
+        return lookupColumnById(columnId)
+                .map(this::getCellElementsForColumn)
+                .orElseGet(Can::empty);
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataTableModel.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/nonscalar/DataTableModel.java
@@ -163,8 +163,8 @@ implements MultiselectChoices {
 
         dataColumns = _Observables.lazy(()->
             managedMember.getElementType()
-            .streamPropertiesForColumnRendering(managedMember.getIdentifier(), managedMember.getOwner())
-            .map(property->new DataColumn(this, property))
+            .streamAssociationsForColumnRendering(managedMember.getIdentifier(), managedMember.getOwner())
+            .map(assoc->new DataColumn(this, assoc))
             .collect(Can.toCan()));
 
         //XXX future extension: the title could dynamically reflect the number of elements selected

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/object/ManagedObjects.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/object/ManagedObjects.java
@@ -244,19 +244,18 @@ public final class ManagedObjects {
 
     // -- PACKING
 
+    /**
+     * If {@code any} is a {@link PackedManagedObject} then returns its unpacked elements,
+     * otherwise collects {@code any} into a {@link Can} unaltered.
+     * <p>
+     * Results in an empty Can if {@code any} is {@code null}.
+     * @param any - nullable
+     */
     public static Can<ManagedObject> unpack(
-            final ObjectSpecification elementSpec, // no longer req.
-            final ManagedObject nonScalar) {
-
-        if(!ManagedObjects.isNullOrUnspecifiedOrEmpty(nonScalar)
-                && !(nonScalar instanceof PackedManagedObject)) {
-            throw _Exceptions.illegalArgument("nonScalar must be in packed form; got %s",
-                    nonScalar.getClass().getName());
-        }
-
-        return isNullOrUnspecifiedOrEmpty(nonScalar)
-                ? Can.empty()
-                : ((PackedManagedObject)nonScalar).unpack();
+            final @Nullable ManagedObject any) {
+        return any instanceof PackedManagedObject
+                    ? ((PackedManagedObject)any).unpack()
+                    : Can.of(any);
     }
 
     // -- COMPARE UTILITIES

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/objectmanager/ObjectManager.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/objectmanager/ObjectManager.java
@@ -21,10 +21,6 @@ package org.apache.causeway.core.metamodel.objectmanager;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import org.apache.causeway.core.metamodel.spec.feature.ObjectActionParameter;
-
-import org.apache.causeway.core.metamodel.spec.feature.OneToOneAssociation;
-
 import org.springframework.lang.Nullable;
 
 import org.apache.causeway.applib.services.bookmark.Bookmark;
@@ -37,6 +33,8 @@ import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.object.ProtoObject;
 import org.apache.causeway.core.metamodel.objectmanager.memento.ObjectMemento;
 import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
+import org.apache.causeway.core.metamodel.spec.feature.ObjectActionParameter;
+import org.apache.causeway.core.metamodel.spec.feature.OneToOneAssociation;
 
 import lombok.NonNull;
 import lombok.val;
@@ -148,13 +146,14 @@ public interface ObjectManager extends HasMetaModelContext {
     // -- ADAPTING POJOS
 
     /**
-     * Not suitable for adapting a non-scalar.
+     * Not suitable for adapting a plural.
      * If {@code pojo} is an entity, automatically memoizes its bookmark.
-     *
      * <p>
      * Resolves injection-points for the result. (Handles service injection.)
+     * <p>
+     * see also {@link #adapt(Object, Supplier)},
+     *      where the 2nd arg supplies the {@link ObjectSpecification} if known (eg for null args).
      *
-     * @see #adapt(Object, Supplier), where the 2nd arg supplies the {@link ObjectSpecification} if known (eg for null args).
      * @see ManagedObject#adaptSingular(ObjectSpecification, Object)
      * @see ManagedObject#adaptParameter(ObjectActionParameter, Object)
      * @see ManagedObject#adaptProperty(OneToOneAssociation, Object)
@@ -164,7 +163,7 @@ public interface ObjectManager extends HasMetaModelContext {
     }
 
     /**
-     * Suitable for adapting a non-scalar.
+     * Suitable for adapting a plural.
      * If {@code pojo} is an entity, automatically memoizes its bookmark.
      * <p>
      * Resolves injection-points for the result. (Handles service injection.)

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/feature/ObjectAssociation.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/feature/ObjectAssociation.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 import org.apache.causeway.applib.annotation.Domain;
 import org.apache.causeway.applib.annotation.Where;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.functional.Either;
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.commons.internal.collections._Maps;
@@ -42,6 +43,13 @@ import lombok.val;
  * Provides reflective access to a field on a domain object.
  */
 public interface ObjectAssociation extends ObjectMember, CurrentHolder {
+
+    /**
+     * Either a singular or a plural.
+     */
+    Either<OneToOneAssociation, OneToManyAssociation> getSpecialization();
+    default boolean isSingular() { return isProperty(); }
+    default boolean isPlural() { return isCollection(); }
 
     /**
      * As per {@link #get(ManagedObject, InteractionInitiatedBy)}, with {@link InteractionInitiatedBy#USER}.

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/feature/ObjectAssociationContainer.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/spec/feature/ObjectAssociationContainer.java
@@ -126,9 +126,9 @@ public interface ObjectAssociationContainer {
     }
 
     /**
-     * Properties visible as columns honoring order and visibility.
+     * Properties and Collections visible as columns honoring order and visibility.
      */
-    Stream<OneToOneAssociation> streamPropertiesForColumnRendering(
+    Stream<ObjectAssociation> streamAssociationsForColumnRendering(
             Identifier memberIdentifier,
             ManagedObject parentObject);
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectAssociationAbstract.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/ObjectAssociationAbstract.java
@@ -19,6 +19,7 @@
 package org.apache.causeway.core.metamodel.specloader.specimpl;
 
 import org.apache.causeway.applib.Identifier;
+import org.apache.causeway.commons.functional.Either;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.facetapi.FacetHolder;
 import org.apache.causeway.core.metamodel.facetapi.FeatureType;
@@ -29,6 +30,8 @@ import org.apache.causeway.core.metamodel.facets.properties.choices.PropertyChoi
 import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
 import org.apache.causeway.core.metamodel.spec.feature.ObjectAssociation;
+import org.apache.causeway.core.metamodel.spec.feature.OneToManyAssociation;
+import org.apache.causeway.core.metamodel.spec.feature.OneToOneAssociation;
 
 public abstract class ObjectAssociationAbstract
 extends ObjectMemberAbstract
@@ -47,6 +50,13 @@ implements ObjectAssociation {
             throw new IllegalArgumentException("field type for '" + getId() + "' must exist");
         }
         this.elementType = elementType;
+    }
+
+    @Override
+    public final Either<OneToOneAssociation, OneToManyAssociation> getSpecialization() {
+        return isSingular()
+                ? Either.left((OneToOneAssociation) this)
+                : Either.right((OneToManyAssociation) this);
     }
 
     @Override

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToManyAssociationDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/OneToManyAssociationDefault.java
@@ -109,7 +109,7 @@ implements OneToManyAssociation {
 
         super.getServiceInjector().injectServicesInto(collection);
 
-        return objectManager.adapt(collection);
+        return objectManager.adapt(collection, this::getElementType);
     }
 
     @Override

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/ObjectSpecificationDefault.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/ObjectSpecificationDefault.java
@@ -58,7 +58,6 @@ import org.apache.causeway.core.metamodel.spec.feature.MixedIn;
 import org.apache.causeway.core.metamodel.spec.feature.ObjectAction;
 import org.apache.causeway.core.metamodel.spec.feature.ObjectAssociation;
 import org.apache.causeway.core.metamodel.spec.feature.ObjectMember;
-import org.apache.causeway.core.metamodel.spec.feature.OneToOneAssociation;
 import org.apache.causeway.core.metamodel.specloader.facetprocessor.FacetProcessor;
 import org.apache.causeway.core.metamodel.specloader.postprocessor.PostProcessor;
 import org.apache.causeway.core.metamodel.specloader.specimpl.FacetedMethodsBuilder;
@@ -313,12 +312,12 @@ implements FacetHolder {
     // -- TABLE COLUMN RENDERING
 
     @Override
-    public final Stream<OneToOneAssociation> streamPropertiesForColumnRendering(
+    public final Stream<ObjectAssociation> streamAssociationsForColumnRendering(
             final Identifier memberIdentifier,
             final ManagedObject parentObject) {
 
-        return new _PropertiesAsColumns(getMetaModelContext())
-            .streamPropertiesForColumnRendering(this, memberIdentifier, parentObject);
+        return new _AssociationsAsColumns(getMetaModelContext())
+            .streamAssociationsForColumnRendering(this, memberIdentifier, parentObject);
     }
 
     // -- DETERMINE INJECTABILITY

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/_AssociationsAsColumns.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/_AssociationsAsColumns.java
@@ -45,7 +45,7 @@ import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
 import org.apache.causeway.core.metamodel.spec.feature.MixedIn;
 import org.apache.causeway.core.metamodel.spec.feature.ObjectAssociation;
-import org.apache.causeway.core.metamodel.spec.feature.OneToOneAssociation;
+import org.apache.causeway.core.metamodel.util.Facets;
 
 import lombok.Getter;
 import lombok.NonNull;
@@ -53,12 +53,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 
 @RequiredArgsConstructor
-class _PropertiesAsColumns implements HasMetaModelContext {
+class _AssociationsAsColumns implements HasMetaModelContext {
 
     @Getter(onMethod_ = {@Override})
     private final MetaModelContext metaModelContext;
 
-    public final Stream<OneToOneAssociation> streamPropertiesForColumnRendering(
+    public final Stream<ObjectAssociation> streamAssociationsForColumnRendering(
             final ObjectSpecification elementType,
             final Identifier memberIdentifier,
             final ManagedObject parentObject) {
@@ -70,43 +70,41 @@ class _PropertiesAsColumns implements HasMetaModelContext {
 
         val whereContext = whereContextFor(memberIdentifier);
 
-        val propertyById = _Maps.<String, OneToOneAssociation>newLinkedHashMap();
+        val assocById = _Maps.<String, ObjectAssociation>newLinkedHashMap();
 
-        elementType.streamProperties(MixedIn.INCLUDED)
-        .filter(property->property.streamFacets()
-                .filter(facet -> facet instanceof HiddenFacet)
+        elementType.streamAssociations(MixedIn.INCLUDED)
+        .filter(assoc->assoc.lookupFacet(HiddenFacet.class).stream()
                 .map(WhereValueFacet.class::cast)
                 .map(WhereValueFacet::where)
                 .noneMatch(where -> where.includes(whereContext)))
-        .filter(associationDoesNotReferenceParent(parentSpecIfAny))
-        .filter(property->filterColumnsUsingSpi(property, elementClass)) // optional SPI to filter columns;
-        .forEach(property->propertyById.put(property.getId(), property));
+        .filter(associationDoesReferenceParent(parentSpecIfAny).negate())
+        .filter(assoc->filterColumnsUsingSpi(assoc, elementClass)) // optional SPI to filter columns;
+        .forEach(assoc->assocById.put(assoc.getId(), assoc));
 
-        val propertyIdsInOrder = _Lists.<String>newArrayList(propertyById.keySet());
+        val assocIdsInOrder = _Lists.<String>newArrayList(assocById.keySet());
 
         // sort by order of occurrence within associated layout, if any
         propertyIdComparator(elementType)
-        .ifPresent(propertyIdsInOrder::sort);
+        .ifPresent(assocIdsInOrder::sort);
 
         // optional SPI to reorder columns
-        sortColumnsUsingSpi(memberIdentifier, parentObject, propertyIdsInOrder, elementClass);
+        sortColumnsUsingSpi(memberIdentifier, parentObject, assocIdsInOrder, elementClass);
 
         // add all ordered columns to the table
-        return propertyIdsInOrder.stream()
-                .map(propertyById::get)
+        return assocIdsInOrder.stream()
+                .map(assocById::get)
                 .filter(_NullSafe::isPresent);
-
     }
 
     // -- HELPER
 
     private boolean filterColumnsUsingSpi(
-            final ObjectAssociation property,
+            final ObjectAssociation assoc,
             final Class<?> elementType) {
         return getServiceRegistry()
                 .select(TableColumnVisibilityService.class)
                 .stream()
-                .noneMatch(x -> x.hides(elementType, property.getId()));
+                .noneMatch(x -> x.hides(elementType, assoc.getId()));
     }
 
     // comparator based on grid facet, that is by order of occurrence within associated layout
@@ -177,23 +175,15 @@ class _PropertiesAsColumns implements HasMetaModelContext {
 
     }
 
-    static Predicate<ObjectAssociation> associationDoesNotReferenceParent(
+    static Predicate<ObjectAssociation> associationDoesReferenceParent(
             final @Nullable ObjectSpecification parentSpec) {
         if(parentSpec == null) {
-            return _Predicates.alwaysTrue();
+            return _Predicates.alwaysFalse();
         }
-        return (final ObjectAssociation property) -> {
-                val hiddenFacet = property.getFacet(HiddenFacet.class);
-                if(hiddenFacet == null) {
-                    return true;
-                }
-                if (hiddenFacet.where() != Where.REFERENCES_PARENT) {
-                    return true;
-                }
-                val propertySpec = property.getElementType();
-                final boolean propertySpecIsOfParentSpec = parentSpec.isOfType(propertySpec);
-                final boolean isVisible = !propertySpecIsOfParentSpec;
-                return isVisible;
+        return (final ObjectAssociation assoc) -> {
+                if(assoc.isCollection()) return false; // never true for collections
+                return Facets.hiddenWhereMatches(Where.REFERENCES_PARENT::equals).test(assoc)
+                        && parentSpec.isOfType(assoc.getElementType());
         };
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/_AssociationsAsColumns.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/_AssociationsAsColumns.java
@@ -176,9 +176,12 @@ class _AssociationsAsColumns implements HasMetaModelContext {
     static Predicate<ObjectAssociation> associationIsVisibleAccordingToHiddenFacet(
             final Identifier memberIdentifier) {
         val whereContext = whereContextFor(memberIdentifier);
-        return (final ObjectAssociation assoc) -> assoc.lookupFacet(HiddenFacet.class).stream()
+        return (final ObjectAssociation assoc) -> assoc.lookupFacet(HiddenFacet.class)
                 .map(WhereValueFacet.class::cast)
                 .map(WhereValueFacet::where)
+                // in case its a plural, ALL_TABLES is the default when not specified otherwise
+                .or(()->assoc.getSpecialization().right().map(__->Where.ALL_TABLES))
+                .stream()
                 .noneMatch(whereHidden -> whereHidden.includes(whereContext)); // if no HiddenFacet is found returns true
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/_AssociationsAsColumns.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/specloader/specimpl/dflt/_AssociationsAsColumns.java
@@ -172,6 +172,11 @@ class _AssociationsAsColumns implements HasMetaModelContext {
 
     /**
      * Returns true if no {@link HiddenFacet} is found that vetoes visibility.
+     * <p>
+     * However, if its a 1-to-Many, whereHidden={@link Where.ALL_TABLES} is used as default
+     * when no {@link HiddenFacet} is found.
+     * @apiNote an alternative would be to prime the meta-model with fallback facets,
+     *      however the current approach is more heap friendly
      */
     static Predicate<ObjectAssociation> associationIsVisibleAccordingToHiddenFacet(
             final Identifier memberIdentifier) {
@@ -179,10 +184,10 @@ class _AssociationsAsColumns implements HasMetaModelContext {
         return (final ObjectAssociation assoc) -> assoc.lookupFacet(HiddenFacet.class)
                 .map(WhereValueFacet.class::cast)
                 .map(WhereValueFacet::where)
-                // in case its a plural, ALL_TABLES is the default when not specified otherwise
+                // in case its a 1-to-Many, whereHidden=ALL_TABLES is the default when not specified otherwise
                 .or(()->assoc.getSpecialization().right().map(__->Where.ALL_TABLES))
                 .stream()
-                .noneMatch(whereHidden -> whereHidden.includes(whereContext)); // if no HiddenFacet is found returns true
+                .noneMatch(whereHidden -> whereHidden.includes(whereContext));
     }
 
     static Predicate<ObjectAssociation> associationDoesReferenceParent(

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/BooleanValueSemanticsProviderTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/BooleanValueSemanticsProviderTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.causeway.applib.exceptions.recoverable.TextEntryParseException;
+import org.apache.causeway.applib.services.placeholder.PlaceholderRenderService.PlaceholderLiteral;
 import org.apache.causeway.core.metamodel.valuesemantics.BooleanValueSemantics;
 
 class BooleanValueSemanticsProviderTest
@@ -80,7 +81,7 @@ extends ValueSemanticsProviderAbstractTestCase<Boolean> {
 
     @Test
     void titleWhenNotSet() throws Exception {
-        assertEquals("(none)",
+        assertEquals(PlaceholderLiteral.NULL_REPRESENTATION.getLiteral(),
                 value.titlePresentation(null, null));
     }
 

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/ValueSemanticsProviderAbstractTestCase.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/ValueSemanticsProviderAbstractTestCase.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.causeway.applib.services.iactnlayer.InteractionService;
+import org.apache.causeway.applib.services.placeholder.PlaceholderRenderService.PlaceholderLiteral;
 import org.apache.causeway.applib.value.Blob;
 import org.apache.causeway.applib.value.Clob;
 import org.apache.causeway.applib.value.semantics.Parser;
@@ -172,7 +173,7 @@ abstract class ValueSemanticsProviderAbstractTestCase<T> {
             assertEquals("",
                     semantics.getRenderer().titlePresentation(null, null));
         } else {
-            assertEquals("(none)",
+            assertEquals(PlaceholderLiteral.NULL_REPRESENTATION.getLiteral(),
                     semantics.getRenderer().titlePresentation(null, null));
         }
 

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/command/CommandDtoFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/command/CommandDtoFactoryDefault.java
@@ -120,9 +120,6 @@ public class CommandDtoFactoryDefault implements CommandDtoFactory {
 
             val argAdapter = argAdapters.getElseFail(paramNum);
 
-            // in case of non-scalar params returns the element type
-            val elementType = actionParameter.getElementType();
-
             final ParamDto paramDto = new ParamDto();
             paramDto.setName(actionParameter.getStaticFriendlyName()
                     .orElseThrow(_Exceptions::unexpectedCodeReach));
@@ -134,7 +131,7 @@ public class CommandDtoFactoryDefault implements CommandDtoFactory {
                 valueMarshaller.recordParamScalar(paramDto, actionParameter, argAdapter);
             } else {
                 //non-scalar
-                val values = ManagedObjects.unpack(elementType, argAdapter);
+                val values = ManagedObjects.unpack(argAdapter);
                 valueMarshaller.recordParamNonScalar(paramDto, actionParameter, values);
             }
 

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/interaction/InteractionDtoFactoryDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/interaction/InteractionDtoFactoryDefault.java
@@ -107,14 +107,12 @@ public class InteractionDtoFactoryDefault implements InteractionDtoFactory {
             final ObjectAction objectAction,
             final ManagedObject resultObject) {
 
-        val elementSpec = objectAction.getElementType();
-
         if(objectAction.getReturnType().isSingular()) {
-            //scalar
+            //singular
             valueMarshaller.recordActionResultScalar(actionInvocationDto, objectAction, resultObject);
         } else {
-            //non-scalar
-            val values = ManagedObjects.unpack(elementSpec, resultObject);
+            //plural
+            val values = ManagedObjects.unpack(resultObject);
             valueMarshaller.recordActionResultNonScalar(actionInvocationDto, objectAction, values);
         }
         return actionInvocationDto;

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/placeholder/PlaceholderRenderServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/placeholder/PlaceholderRenderServiceDefault.java
@@ -19,6 +19,7 @@
 package org.apache.causeway.core.runtimeservices.placeholder;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.Priority;
 import javax.inject.Inject;
@@ -67,6 +68,8 @@ implements PlaceholderRenderService {
         return _BootstrapBadge.builder()
                 .caption(translateAndInterpolate(placeholderLiteral, vars))
                 .cssClass("placeholder-literal-" + placeholderLiteral.name().toLowerCase())
+                .href(Optional.ofNullable(vars).map(map->map.get("href")).orElse(null))
+                //.nestedCaption(Optional.ofNullable(vars).map(map->map.get("number")).orElse(null))
                 .build()
                 .toHtml();
     }

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/placeholder/PlaceholderRenderServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/placeholder/PlaceholderRenderServiceDefault.java
@@ -69,7 +69,7 @@ implements PlaceholderRenderService {
                 .caption(translateAndInterpolate(placeholderLiteral, vars))
                 .cssClass("placeholder-literal-" + placeholderLiteral.name().toLowerCase())
                 .href(Optional.ofNullable(vars).map(map->map.get("href")).orElse(null))
-                //.nestedCaption(Optional.ofNullable(vars).map(map->map.get("number")).orElse(null))
+                .nestedCaption(Optional.ofNullable(vars).map(map->map.get("..")).orElse(null))
                 .build()
                 .toHtml();
     }

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/placeholder/PlaceholderRenderServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/placeholder/PlaceholderRenderServiceDefault.java
@@ -18,11 +18,14 @@
  */
 package org.apache.causeway.core.runtimeservices.placeholder;
 
+import java.util.Map;
+
 import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import org.apache.causeway.applib.annotation.PriorityPrecedence;
@@ -51,19 +54,28 @@ implements PlaceholderRenderService {
     @Inject private TranslationService translationService;
 
     @Override
-    public String asText(@NonNull final PlaceholderLiteral placeholderLiteral) {
-        val translatedPlainText = translationService
-                .translate(TranslationContext.empty(), placeholderLiteral.getLiteral());
-        return "(" + translatedPlainText + ")";
+    public String asText(
+            @NonNull final PlaceholderLiteral placeholderLiteral,
+            @Nullable final Map<String, String> vars) {
+        return "(" + translateAndInterpolate(placeholderLiteral, vars) + ")";
     }
 
     @Override
-    public String asHtml(@NonNull final PlaceholderLiteral placeholderLiteral) {
+    public String asHtml(
+            @NonNull final PlaceholderLiteral placeholderLiteral,
+            @Nullable final Map<String, String> vars) {
         return _BootstrapBadge.builder()
-                .caption(asText(placeholderLiteral))
-                .cssClass("placeholder-literal-" + placeholderLiteral.getLiteral())
+                .caption(translateAndInterpolate(placeholderLiteral, vars))
+                .cssClass("placeholder-literal-" + placeholderLiteral.name().toLowerCase())
                 .build()
                 .toHtml();
+    }
+
+    private String translateAndInterpolate(
+            final PlaceholderLiteral placeholderLiteral, final Map<String, String> vars) {
+        val translatedPlainText = translationService
+                .translate(TranslationContext.empty(), placeholderLiteral.getLiteral());
+        return PlaceholderRenderService.interpolate(translatedPlainText, vars);
     }
 
 }

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/placeholder/PlaceholderRenderServiceDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/placeholder/PlaceholderRenderServiceDefault.java
@@ -65,11 +65,14 @@ implements PlaceholderRenderService {
     public String asHtml(
             @NonNull final PlaceholderLiteral placeholderLiteral,
             @Nullable final Map<String, String> vars) {
+
+        val href = Optional.ofNullable(vars).map(map->map.get("href"));
+
         return _BootstrapBadge.builder()
                 .caption(translateAndInterpolate(placeholderLiteral, vars))
                 .cssClass("placeholder-literal-" + placeholderLiteral.name().toLowerCase())
-                .href(Optional.ofNullable(vars).map(map->map.get("href")).orElse(null))
-                .nestedCaption(Optional.ofNullable(vars).map(map->map.get("..")).orElse(null))
+                .href(href.orElse(null))
+                .nestedCaption(href.map(__->"..").orElse(null))
                 .build()
                 .toHtml();
     }

--- a/extensions/vw/exceldownload/wicket-ui/src/main/java/org/apache/causeway/extensions/viewer/wicket/exceldownload/ui/components/ExcelFileModel.java
+++ b/extensions/vw/exceldownload/wicket-ui/src/main/java/org/apache/causeway/extensions/viewer/wicket/exceldownload/ui/components/ExcelFileModel.java
@@ -28,6 +28,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -48,6 +49,12 @@ import lombok.val;
 class ExcelFileModel extends LoadableDetachableModel<File> {
 
     private static final long serialVersionUID = 1L;
+
+    /**
+     * If a cell's cardinality exceeds this threshold, truncate with '... has more' label at the end.
+     */
+    private static final int MAX_CELL_ELEMENTS = 5;
+    private static final String POI_LINE_DELIMITER = "\n";
 
     private final EntityCollectionModel model;
 
@@ -118,7 +125,10 @@ class ExcelFileModel extends LoadableDetachableModel<File> {
                     i=0;
                     for(val column : dataColumns) {
                         final Cell cell = row.createCell((short) i++);
-                        setCellValue(dataRow.getCellElementsForColumn(column), cell, dateCellStyle);
+                        setCellValue(dataRow.getCellElementsForColumn(column)
+                                .filter(managedObject->managedObject.getPojo()!=null),
+                                cell,
+                                dateCellStyle);
                     }
                 }
 
@@ -147,15 +157,35 @@ class ExcelFileModel extends LoadableDetachableModel<File> {
     }
 
     private void setCellValue(
-            final Can<ManagedObject> cellValues,
+            final Can<ManagedObject> cellElements, // pre-filtered, so contains only non-null pojos
             final Cell cell,
             final CellStyle dateCellStyle) {
 
-        //TODO[CAUSEWAY-3578] handle more than one value
-        val valueAsObj = cellValues.isNotEmpty()
-                ? cellValues.getFirstElseFail().getPojo()
-                : null;
+        if(cellElements.isEmpty()) {
+            cell.setBlank();
+            return;
+        }
 
+        if(cellElements.isCardinalityMultiple()) {
+            String joinedElementsLiteral = cellElements.stream()
+                .limit(MAX_CELL_ELEMENTS)
+                .map(ManagedObject::getTitle)
+                .collect(Collectors.joining(POI_LINE_DELIMITER));
+
+            // if cardinality exceeds threshold, truncate with 'has more' label at the end
+            final int overflow = cellElements.size()-MAX_CELL_ELEMENTS;
+            if(overflow>0) {
+                joinedElementsLiteral += POI_LINE_DELIMITER + String.format("(has %d more)", overflow);
+            }
+
+            cell.setCellValue(joinedElementsLiteral);
+            return;
+        }
+
+        val singleton = cellElements.getFirstElseFail();
+        val valueAsObj = singleton.getPojo();
+
+        // event though filtered for null by caller, keep this as a guard
         // null
         if(valueAsObj == null) {
             cell.setBlank();
@@ -236,10 +266,7 @@ class ExcelFileModel extends LoadableDetachableModel<File> {
             return;
         }
 
-        //TODO[CAUSEWAY-3578] handle more than one value
-        val cellValue = cellValues.getFirstElseFail();
-
-        final String objectAsStr = cellValue.getTitle();
+        final String objectAsStr = singleton.getTitle();
         cell.setCellValue(objectAsStr);
         return;
     }

--- a/extensions/vw/exceldownload/wicket-ui/src/main/java/org/apache/causeway/extensions/viewer/wicket/exceldownload/ui/components/ExcelFileModel.java
+++ b/extensions/vw/exceldownload/wicket-ui/src/main/java/org/apache/causeway/extensions/viewer/wicket/exceldownload/ui/components/ExcelFileModel.java
@@ -38,6 +38,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.wicket.model.LoadableDetachableModel;
 
+import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataTableModel;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel;
@@ -117,7 +118,7 @@ class ExcelFileModel extends LoadableDetachableModel<File> {
                     i=0;
                     for(val column : dataColumns) {
                         final Cell cell = row.createCell((short) i++);
-                        setCellValue(dataRow.getCellElement(column), cell, dateCellStyle);
+                        setCellValue(dataRow.getCellElementsForColumn(column), cell, dateCellStyle);
                     }
                 }
 
@@ -146,11 +147,14 @@ class ExcelFileModel extends LoadableDetachableModel<File> {
     }
 
     private void setCellValue(
-            final ManagedObject cellValue,
+            final Can<ManagedObject> cellValues,
             final Cell cell,
             final CellStyle dateCellStyle) {
 
-        val valueAsObj = cellValue!=null ? cellValue.getPojo() : null;
+        //TODO[CAUSEWAY-3578] handle more than one value
+        val valueAsObj = cellValues.isNotEmpty()
+                ? cellValues.getFirstElseFail().getPojo()
+                : null;
 
         // null
         if(valueAsObj == null) {
@@ -231,6 +235,9 @@ class ExcelFileModel extends LoadableDetachableModel<File> {
             setCellValueForDouble(cell, value);
             return;
         }
+
+        //TODO[CAUSEWAY-3578] handle more than one value
+        val cellValue = cellValues.getFirstElseFail();
 
         final String objectAsStr = cellValue.getTitle();
         cell.setCellValue(objectAsStr);

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/ScalarModelWithMultiChoice.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/ScalarModelWithMultiChoice.java
@@ -69,7 +69,7 @@ implements
     public ArrayList<ObjectMemento> getObject() {
 
         val packedValue = pendingValue().getValue().getValue();
-        val unpackedValues = ManagedObjects.unpack(scalarModel().getScalarTypeSpec(), packedValue);
+        val unpackedValues = ManagedObjects.unpack(packedValue);
 
         log.debug("getObject() as unpackedValue {}", unpackedValues);
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/ValueModel.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/ValueModel.java
@@ -38,8 +38,8 @@ extends ModelAbstract<ManagedObject> {
     // -- FACTORIES
 
     public static ValueModel of(
-            final @NonNull  MetaModelContext commonContext,
-            final @NonNull  ObjectMember objectMember,
+            final @NonNull MetaModelContext commonContext,
+            final @NonNull ObjectMember objectMember,
             final @NonNull ManagedObject valueAdapter) {
         return new ValueModel(commonContext, objectMember, valueAdapter);
     }
@@ -50,11 +50,11 @@ extends ModelAbstract<ManagedObject> {
 
     private ValueModel(
             final MetaModelContext commonContext,
-            final @NonNull  ObjectMember objectMember,
+            final @NonNull ObjectMember objectMember,
             final @NonNull ManagedObject valueAdapter) {
         super(commonContext);
         this.objectMemberMemento = ObjectMemberMemento.forMember(objectMember);
-        adapterMemento = valueAdapter.getMemento().orElseThrow();
+        this.adapterMemento = valueAdapter.getMemento().orElseThrow();
     }
 
     @Override

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collection/CollectionPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collection/CollectionPanel.java
@@ -30,7 +30,7 @@ import org.apache.causeway.viewer.wicket.ui.components.actionmenu.entityactions.
 import org.apache.causeway.viewer.wicket.ui.components.collection.bulk.MultiselectToggleProvider;
 import org.apache.causeway.viewer.wicket.ui.components.collection.selector.CollectionPresentationSelectorPanel;
 import org.apache.causeway.viewer.wicket.ui.components.collection.selector.CollectionPresentationSelectorProvider;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericToggleboxColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 import org.apache.causeway.viewer.wicket.ui.components.scalars.ScalarPanelAbstract;
 import org.apache.causeway.viewer.wicket.ui.panels.PanelAbstract;
 
@@ -87,15 +87,15 @@ implements
 
     // -- MULTI SELECTION SUPPORT
 
-    private transient Optional<GenericToggleboxColumn> toggleboxColumn;
+    private transient Optional<ToggleboxColumn> toggleboxColumn;
 
     @Override
-    public GenericToggleboxColumn getToggleboxColumn() {
+    public ToggleboxColumn getToggleboxColumn() {
         if(toggleboxColumn == null) {
             val collModel = getModel();
             val collMetaModel = collModel.getMetaModel();
             toggleboxColumn =  collMetaModel.hasAssociatedActionsWithChoicesFromThisCollection()
-                    ? Optional.of(new GenericToggleboxColumn(super.getMetaModelContext(), collModel.delegate()))
+                    ? Optional.of(new ToggleboxColumn(super.getMetaModelContext(), collModel.delegate()))
                     : Optional.empty();
         }
         return toggleboxColumn.orElse(null);

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collection/bulk/MultiselectToggleProvider.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collection/bulk/MultiselectToggleProvider.java
@@ -20,9 +20,9 @@ package org.apache.causeway.viewer.wicket.ui.components.collection.bulk;
 
 import java.io.Serializable;
 
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericToggleboxColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 
 public interface MultiselectToggleProvider extends Serializable {
 
-    GenericToggleboxColumn getToggleboxColumn();
+    ToggleboxColumn getToggleboxColumn();
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
@@ -40,7 +40,7 @@ import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.viewer.wicket.model.hints.UiHintContainer;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericToggleboxColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 import lombok.val;
@@ -52,7 +52,7 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
     static final String UIHINT_PAGE_NUMBER = "pageNumber";
 
     private final CollectionContentsSortableDataProvider dataProvider;
-    private final GenericToggleboxColumn toggleboxColumn;
+    private final ToggleboxColumn toggleboxColumn;
 
     private CausewayAjaxHeadersToolbar headersToolbar;
     private CausewayAjaxNavigationToolbar navigationToolbar;
@@ -62,7 +62,7 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
             final List<? extends IColumn<DataRow, String>> columns,
             final CollectionContentsSortableDataProvider dataProvider,
             final int rowsPerPage,
-            final GenericToggleboxColumn toggleboxColumn) {
+            final ToggleboxColumn toggleboxColumn) {
 
         super(id, columns, dataProvider, rowsPerPage);
         this.dataProvider = dataProvider;

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxHeadersToolbarAbstract.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxHeadersToolbarAbstract.java
@@ -42,7 +42,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.util.string.Strings;
 
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericTitleColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumn;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 import de.agilecoders.wicket.core.util.Attributes;
@@ -150,7 +150,7 @@ public abstract class CausewayAjaxHeadersToolbarAbstract<S> extends AbstractTool
                 Component sortIcon = newSortIcon("sortIcon", column, stateLocator);
                 header.add(label, sortIcon);
 
-                if(column instanceof GenericTitleColumn) {
+                if(column instanceof TitleColumn) {
                     Wkt.cssAppend(header, "title-column");
                 }
             }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxNavigationToolbar.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxNavigationToolbar.java
@@ -28,7 +28,7 @@ import org.apache.causeway.viewer.wicket.model.hints.UiHintContainer;
 import org.apache.causeway.viewer.wicket.model.models.HasCommonContext;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.model.util.WktContext;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericToggleboxColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 public class CausewayAjaxNavigationToolbar extends AjaxNavigationToolbar
@@ -39,11 +39,11 @@ implements HasCommonContext {
     private static final String navigatorContainerId = "span";
     private static final String ID_SHOW_ALL = "showAll";
     private static final String HINT_KEY_SHOW_ALL = "showAll";
-    private final GenericToggleboxColumn toggleboxColumn;
+    private final ToggleboxColumn toggleboxColumn;
 
     public CausewayAjaxNavigationToolbar(
             final DataTable<?, ?> table,
-            final GenericToggleboxColumn toggleboxColumn) {
+            final ToggleboxColumn toggleboxColumn) {
 
         super(table);
         this.toggleboxColumn = toggleboxColumn;

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
@@ -35,12 +35,13 @@ import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel.Variant;
 import org.apache.causeway.viewer.wicket.ui.components.collection.bulk.MultiselectToggleProvider;
 import org.apache.causeway.viewer.wicket.ui.components.collection.count.CollectionCountProvider;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericColumn;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumn;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ColumnAbbreviationOptions;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericColumn;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.PluralColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.PluralColumn.RenderOptions;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.SingularColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumn;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 import org.apache.causeway.viewer.wicket.ui.panels.PanelAbstract;
 
 import lombok.val;
@@ -192,7 +193,9 @@ implements CollectionCountProvider {
                 collection.getId(),
                 collection.getId(),
                 parentTypeName,
-                collection.getCanonicalDescription());
+                collection.getCanonicalDescription(),
+                // can hook up with global config later
+                RenderOptions.builder().build());
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
@@ -37,7 +37,7 @@ import org.apache.causeway.viewer.wicket.ui.components.collection.bulk.Multisele
 import org.apache.causeway.viewer.wicket.ui.components.collection.count.CollectionCountProvider;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericColumn;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumn;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumnOptions;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ColumnAbbreviationOptions;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.PluralColumn;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.SingularColumn;
@@ -137,7 +137,7 @@ implements CollectionCountProvider {
                     ? wktConfig.getMaxTitleLengthInParentedTables()
                     : wktConfig.getMaxTitleLengthInStandaloneTables();
 
-        val opts = TitleColumnOptions.builder()
+        val opts = ColumnAbbreviationOptions.builder()
             .maxElementTitleLength(columns.size()==0
                             ? wktConfig.getMaxTitleLengthInTablesNotHavingAnyPropertyColumn()
                             : -1 /* don't override */)

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
@@ -163,12 +163,12 @@ implements CollectionCountProvider {
         elementTypeSpec.streamAssociationsForColumnRendering(memberIdentifier, parentObject)
         .map(ObjectAssociation::getSpecialization)
         .map(spez->spez.fold(
-                this::createObjectAdapterPropertyColumnSingular,
-                this::createObjectAdapterPropertyColumnPlural))
+                this::createSingularColumn,
+                this::createPluralColumn))
         .forEach(columns::add);
     }
 
-    private SingularColumn createObjectAdapterPropertyColumnSingular(final OneToOneAssociation property) {
+    private SingularColumn createSingularColumn(final OneToOneAssociation property) {
         val collectionModel = getModel();
         final String parentTypeName = property.getDeclaringType().getLogicalTypeName();
 
@@ -182,7 +182,7 @@ implements CollectionCountProvider {
                 property.getCanonicalDescription());
     }
 
-    private PluralColumn createObjectAdapterPropertyColumnPlural(final OneToManyAssociation collection) {
+    private PluralColumn createPluralColumn(final OneToManyAssociation collection) {
         val collectionModel = getModel();
         final String parentTypeName = collection.getDeclaringType().getLogicalTypeName();
 
@@ -194,7 +194,7 @@ implements CollectionCountProvider {
                 collection.getId(),
                 parentTypeName,
                 collection.getCanonicalDescription(),
-                // can hook up with global config later
+                // future work: can hook up with global config
                 RenderOptions.builder().build());
     }
 

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/AssociationColumnAbstract.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/AssociationColumnAbstract.java
@@ -21,26 +21,18 @@ package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxt
 import java.util.Optional;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
 
 import org.apache.causeway.commons.internal.base._Strings;
-import org.apache.causeway.core.metamodel.commons.ViewOrEditMode;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
-import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataRow;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
-import org.apache.causeway.viewer.commons.model.components.UiComponentType;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel;
-import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.ui.ComponentFactory;
 import org.apache.causeway.viewer.wicket.ui.app.registry.ComponentFactoryRegistry;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.CollectionContentsAsAjaxTablePanel;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 import org.apache.causeway.viewer.wicket.ui.util.WktTooltips;
-
-import lombok.val;
 
 /**
  * A {@link GenericColumnAbstract column} within a
@@ -51,34 +43,34 @@ import lombok.val;
  * Looks up the {@link ComponentFactory} to render the property from the
  * {@link ComponentFactoryRegistry}.
  */
-public final class GenericPropertyColumn
+public abstract class AssociationColumnAbstract
 extends GenericColumnAbstract {
 
     private static final long serialVersionUID = 1L;
 
-    private final EntityCollectionModel.Variant collectionVariant;
-    private final String propertyId;
-    private final String parentTypeName;
-    private final String describedAs;
+    protected final EntityCollectionModel.Variant collectionVariant;
+    protected final String memberId;
+    protected final String parentTypeName;
+    protected final String describedAs;
 
-    public GenericPropertyColumn(
+    public AssociationColumnAbstract(
             final MetaModelContext commonContext,
             final EntityCollectionModel.Variant collectionVariant,
             final IModel<String> columnNameModel,
             final String sortProperty,
-            final String propertyId,
+            final String memberId,
             final String parentTypeName,
             final Optional<String> describedAs) {
 
         super(commonContext, columnNameModel, sortProperty);
         this.collectionVariant = collectionVariant;
-        this.propertyId = propertyId;
+        this.memberId = memberId;
         this.parentTypeName = parentTypeName;
         this.describedAs = describedAs.orElse(null);
     }
 
     @Override
-    public Component getHeader(final String componentId) {
+    public final Component getHeader(final String componentId) {
         final Label label = new Label(componentId, getDisplayModel());
         label.setEscapeModelStrings(true); // the default anyway
         if(describedAs!=null) {
@@ -88,37 +80,12 @@ extends GenericColumnAbstract {
     }
 
     @Override
-    public String getCssClass() {
+    public final String getCssClass() {
         final String cssClass = super.getCssClass();
         return (_Strings.isNotEmpty(cssClass)
                         ? (cssClass + " ")
                         : "")
-                + Wkt.cssNormalize("causeway-" + parentTypeName + "-" + propertyId);
-    }
-
-    @Override
-    public void populateItem(
-            final Item<ICellPopulator<DataRow>> cellItem,
-            final String componentId,
-            final IModel<DataRow> rowModel) {
-
-        cellItem.add(createComponent(componentId, rowModel));
-    }
-
-    private Component createComponent(final String id, final IModel<DataRow> rowModel) {
-
-        val domainObject = rowModel.getObject().getRowElement();
-        val property = domainObject.getSpecification().getPropertyElseFail(propertyId);
-        val entityModel = UiObjectWkt.ofAdapter(super.getMetaModelContext(), domainObject);
-
-        val scalarModel = entityModel
-                .getPropertyModel(
-                        property,
-                        ViewOrEditMode.VIEWING,
-                        collectionVariant.getColumnRenderingHint());
-
-        return findComponentFactory(UiComponentType.SCALAR_NAME_AND_VALUE, scalarModel)
-                .createComponent(id, scalarModel);
+                + Wkt.cssNormalize("causeway-" + parentTypeName + "-" + memberId);
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ColumnAbbreviationOptions.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ColumnAbbreviationOptions.java
@@ -36,14 +36,14 @@ import lombok.Builder;
  * @since 2.0.0
  */
 @lombok.Value @Builder
-public class TitleColumnOptions implements Serializable {
+public class ColumnAbbreviationOptions implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     @Builder.Default
     private final int maxElementTitleLength = -1;
 
-    private static final MetaDataKey<TitleColumnOptions> KEY = new MetaDataKey<>() {
+    private static final MetaDataKey<ColumnAbbreviationOptions> KEY = new MetaDataKey<>() {
         private static final long serialVersionUID = 1L; };
 
     public <T extends Component> T applyTo(final T component) {
@@ -51,7 +51,7 @@ public class TitleColumnOptions implements Serializable {
         return component;
     }
 
-    public static Optional<TitleColumnOptions> lookupIn(final @Nullable Component component) {
+    public static Optional<ColumnAbbreviationOptions> lookupIn(final @Nullable Component component) {
         return Optional.ofNullable(component)
                 .map(comp->comp.getMetaData(KEY));
     }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/GenericColumnAbstract.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/GenericColumnAbstract.java
@@ -28,6 +28,8 @@ import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
+import org.apache.causeway.applib.services.i18n.TranslationContext;
+import org.apache.causeway.applib.services.placeholder.PlaceholderRenderService;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataRow;
 import org.apache.causeway.viewer.commons.model.components.UiComponentType;
@@ -103,6 +105,14 @@ implements GenericColumn {
             componentRegistry = componentFactoryRegistryAccessor.getComponentFactoryRegistry();
         }
         return componentRegistry;
+    }
+
+    protected PlaceholderRenderService getPlaceholderRenderService() {
+        return getMetaModelContext().getPlaceholderRenderService();
+    }
+
+    protected String translate(final String raw) {
+        return getMetaModelContext().getTranslationService().translate(TranslationContext.empty(), raw);
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/GenericColumnAbstract.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/GenericColumnAbstract.java
@@ -19,19 +19,25 @@
 package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns;
 
 import org.apache.wicket.Application;
+import org.apache.wicket.Component;
+import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxFallbackDefaultDataTable;
+import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.AbstractColumn;
+import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataRow;
 import org.apache.causeway.viewer.commons.model.components.UiComponentType;
+import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
 import org.apache.causeway.viewer.wicket.model.util.WktContext;
 import org.apache.causeway.viewer.wicket.ui.ComponentFactory;
 import org.apache.causeway.viewer.wicket.ui.app.registry.ComponentFactoryRegistry;
 import org.apache.causeway.viewer.wicket.ui.app.registry.HasComponentFactoryRegistry;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.CollectionContentsAsAjaxTablePanel;
+import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 import lombok.val;
 
@@ -64,6 +70,24 @@ implements GenericColumn {
         super(columnNameModel, sortColumn);
         this.commonContext = commonContext;
     }
+
+    @Override
+    public final void populateItem(
+            final Item<ICellPopulator<DataRow>> cellItem,
+            final String componentId,
+            final IModel<DataRow> rowModel) {
+        cellItem.add(createCellComponent(componentId, rowModel.getObject(), ((DataRowWkt)rowModel).getDataRowToggle()));
+        if(this instanceof TitleColumn) {
+            Wkt.cssAppend(cellItem, "title-column");
+        } else if(this instanceof ToggleboxColumn) {
+            Wkt.cssAppend(cellItem, "togglebox-column");
+            final MarkupContainer row = cellItem.getParent().getParent();
+            row.setOutputMarkupId(true);
+        }
+    }
+
+    protected abstract Component createCellComponent(
+            final String componentId, final DataRow dataRow, IModel<Boolean> dataRowToggle);
 
     public MetaModelContext getMetaModelContext() {
         return commonContext = WktContext.computeIfAbsent(commonContext);

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/PluralColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/PluralColumn.java
@@ -1,0 +1,63 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns;
+
+import java.util.Optional;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.model.IModel;
+
+import org.apache.causeway.core.metamodel.context.MetaModelContext;
+import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataRow;
+import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel;
+import org.apache.causeway.viewer.wicket.ui.util.Wkt;
+
+public final class PluralColumn
+extends AssociationColumnAbstract {
+
+    private static final long serialVersionUID = 1L;
+
+    public PluralColumn(
+            final MetaModelContext commonContext,
+            final EntityCollectionModel.Variant collectionVariant,
+            final IModel<String> columnNameModel,
+            final String sortProperty,
+            final String propertyId,
+            final String parentTypeName,
+            final Optional<String> describedAs) {
+        super(commonContext, collectionVariant, columnNameModel, sortProperty, propertyId, parentTypeName, describedAs);
+    }
+
+    @Override
+    protected Component createCellComponent(
+            final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
+
+        dataRow.getCellElementsForColumn(memberId)
+        ;
+
+
+
+
+        //TODO[CAUSEWAY-3578]
+
+
+        return Wkt.label(componentId, "TODO[CAUSEWAY-3578]");
+    }
+
+}

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/PluralColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/PluralColumn.java
@@ -19,6 +19,7 @@
 package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 
@@ -26,6 +27,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.IModel;
 
+import org.apache.causeway.applib.services.linking.DeepLinkService;
 import org.apache.causeway.applib.services.placeholder.PlaceholderRenderService.PlaceholderLiteral;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataRow;
@@ -94,10 +96,16 @@ extends AssociationColumnAbstract {
         // if cardinality exceeds threshold, truncate with '... has more' label at the end
         final int overflow = cellElements.size()-opts.maxElements();
         if(overflow>0) {
-            //val hasMoreText = String.format("... " + translate("has %d more"), overflow);
-            //Wkt.labelAdd(container, container.newChildId(), hasMoreText);
+
+            val href = getMetaModelContext().getServiceRegistry().lookupService(DeepLinkService.class)
+                    .map(deepLinkService->deepLinkService.deepLinkFor(dataRow.getRowElement()))
+                    .map(URI::toString)
+                    .orElse("#");
+
             Wkt.markupAdd(container, container.newChildId(),
-                    getPlaceholderRenderService().asHtml(PlaceholderLiteral.HAS_MORE, Map.of("number", ""+overflow)));
+                    getPlaceholderRenderService().asHtml(PlaceholderLiteral.HAS_MORE,
+                            Map.of("number", ""+overflow,
+                                   "href", href)));
         }
 
         return container;

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/PluralColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/PluralColumn.java
@@ -21,12 +21,19 @@ package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxt
 import java.util.Optional;
 
 import org.apache.wicket.Component;
+import org.apache.wicket.markup.repeater.RepeatingView;
 import org.apache.wicket.model.IModel;
 
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataRow;
+import org.apache.causeway.core.metamodel.object.ManagedObject;
+import org.apache.causeway.core.metamodel.object.ManagedObjects;
+import org.apache.causeway.viewer.commons.model.components.UiComponentType;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel;
+import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
+
+import lombok.val;
 
 public final class PluralColumn
 extends AssociationColumnAbstract {
@@ -48,16 +55,46 @@ extends AssociationColumnAbstract {
     protected Component createCellComponent(
             final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
 
+        //TODO[CAUSEWAY-3578] if empty, should we render the 'empty' badge or nothing?
+        //TODO[CAUSEWAY-3578] if cardinality exceeds certain threshold, truncate with 'has more...' label at the end
+
+        val container = new RepeatingView(componentId);
+
         dataRow.getCellElementsForColumn(memberId)
-        ;
+            .forEach(cellElement->container
+                    .add(createCellElementComponent(container.newChildId(), cellElement)));
 
+        return container;
+    }
 
+    /**
+     * Inspired by {@link TitleColumn}
+     */
+    private Component createCellElementComponent(
+            final String componentId, final ManagedObject cellElement) {
 
+        if(ManagedObjects.isValue(cellElement)) {
+//            val objectMember = dataRow.getParentTable().getMetaModel();
+//            val valueModel = ValueModel.of(super.getMetaModelContext(), objectMember, cellElement);
+//            val componentFactory = findComponentFactory(UiComponentType.VALUE, valueModel);
+//            return componentFactory.createComponent(componentId, valueModel);
 
-        //TODO[CAUSEWAY-3578]
+            //TODO[CAUSEWAY-3578] implement value rendering
+            return Wkt.label(componentId, "TODO[CAUSEWAY-3578]");
+        }
 
+        val uiObject = UiObjectWkt.ofAdapterForCollection(super.getMetaModelContext(), cellElement, collectionVariant);
 
-        return Wkt.label(componentId, "TODO[CAUSEWAY-3578]");
+        val componentFactory = findComponentFactory(UiComponentType.ENTITY_LINK, uiObject);
+        final Component entityLink =
+                componentFactory.createComponent(componentId, uiObject);
+
+        ColumnAbbreviationOptions.builder()
+                .maxElementTitleLength(50) //TODO[CAUSEWAY-3578] should be a config option
+                .build()
+                .applyTo(entityLink);
+
+        return entityLink;
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/SingularColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/SingularColumn.java
@@ -1,0 +1,68 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns;
+
+import java.util.Optional;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.model.IModel;
+
+import org.apache.causeway.core.metamodel.commons.ViewOrEditMode;
+import org.apache.causeway.core.metamodel.context.MetaModelContext;
+import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataRow;
+import org.apache.causeway.viewer.commons.model.components.UiComponentType;
+import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel;
+import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
+
+import lombok.val;
+
+public final class SingularColumn
+extends AssociationColumnAbstract {
+
+    private static final long serialVersionUID = 1L;
+
+    public SingularColumn(
+            final MetaModelContext commonContext,
+            final EntityCollectionModel.Variant collectionVariant,
+            final IModel<String> columnNameModel,
+            final String sortProperty,
+            final String propertyId,
+            final String parentTypeName,
+            final Optional<String> describedAs) {
+        super(commonContext, collectionVariant, columnNameModel, sortProperty, propertyId, parentTypeName, describedAs);
+    }
+
+    @Override
+    protected Component createCellComponent(
+            final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
+        val rowElement = dataRow.getRowElement();
+        val rowElementModel = UiObjectWkt.ofAdapter(super.getMetaModelContext(), rowElement);
+        val property = rowElement.getSpecification().getPropertyElseFail(memberId);
+
+        val scalarModel = rowElementModel
+                .getPropertyModel(
+                        property,
+                        ViewOrEditMode.VIEWING,
+                        collectionVariant.getColumnRenderingHint());
+
+        return findComponentFactory(UiComponentType.SCALAR_NAME_AND_VALUE, scalarModel)
+                .createComponent(componentId, scalarModel);
+    }
+
+}

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/TitleColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/TitleColumn.java
@@ -38,7 +38,7 @@ extends GenericColumnAbstract {
 
     private static final long serialVersionUID = 1L;
     private final Variant variant;
-    private final TitleColumnOptions opts;
+    private final ColumnAbbreviationOptions opts;
     private final Bookmark contextBookmark;
 
     public TitleColumn(
@@ -46,7 +46,7 @@ extends GenericColumnAbstract {
             final Variant variant,
             final Bookmark contextBookmark,
             final int maxColumnTitleLength,
-            final TitleColumnOptions opts) {
+            final ColumnAbbreviationOptions opts) {
 
         super(commonContext, columnName(variant, maxColumnTitleLength)); // i18n
         this.variant = variant;

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/TitleColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/TitleColumn.java
@@ -19,8 +19,6 @@
 package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
-import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
 import org.springframework.lang.Nullable;
 
@@ -32,24 +30,23 @@ import org.apache.causeway.viewer.commons.model.components.UiComponentType;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel.Variant;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.model.models.ValueModel;
-import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 import lombok.val;
 
-public final class GenericTitleColumn
+public final class TitleColumn
 extends GenericColumnAbstract {
 
     private static final long serialVersionUID = 1L;
     private final Variant variant;
-    private final GenericTitleColumnOptions opts;
+    private final TitleColumnOptions opts;
     private final Bookmark contextBookmark;
 
-    public GenericTitleColumn(
+    public TitleColumn(
             final MetaModelContext commonContext,
             final Variant variant,
             final Bookmark contextBookmark,
             final int maxColumnTitleLength,
-            final GenericTitleColumnOptions opts) {
+            final TitleColumnOptions opts) {
 
         super(commonContext, columnName(variant, maxColumnTitleLength)); // i18n
         this.variant = variant;
@@ -58,13 +55,25 @@ extends GenericColumnAbstract {
     }
 
     @Override
-    public void populateItem(
-            final Item<ICellPopulator<DataRow>> cellItem,
-            final String componentId,
-            final IModel<DataRow> rowModel) {
+    protected Component createCellComponent(
+            final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
+        val rowElement = dataRow.getRowElement();
 
-        cellItem.add(createComponent(componentId, rowModel));
-        Wkt.cssAppend(cellItem, "title-column");
+        if(ManagedObjects.isValue(rowElement)) {
+            val objectMember = dataRow.getParentTable().getMetaModel();
+            val valueModel = ValueModel.of(super.getMetaModelContext(), objectMember, rowElement);
+            val componentFactory = findComponentFactory(UiComponentType.VALUE, valueModel);
+            return componentFactory.createComponent(componentId, valueModel);
+        }
+
+        val uiObject = UiObjectWkt.ofAdapterForCollection(super.getMetaModelContext(), rowElement, variant);
+        uiObject.setContextBookmarkIfAny(contextBookmark);
+
+        // will use EntityLinkSimplePanelFactory as model is an EntityModel
+        val componentFactory = findComponentFactory(UiComponentType.ENTITY_LINK, uiObject);
+        final Component entityLink = opts.applyTo(
+                componentFactory.createComponent(componentId, uiObject));
+        return entityLink;
     }
 
     // -- HELPER
@@ -76,28 +85,6 @@ extends GenericColumnAbstract {
             return "";
         }
         return (variant.isParented() ? "Related ":"") + "Object";
-    }
-
-    private Component createComponent(final String id, final IModel<DataRow> rowModel) {
-        val dataRow = rowModel.getObject();
-
-        val adapter = dataRow.getRowElement();
-
-        if(ManagedObjects.isValue(adapter)) {
-            val objectMember = dataRow.getParentTable().getMetaModel();
-            val valueModel = ValueModel.of(super.getMetaModelContext(), objectMember, adapter);
-            val componentFactory = findComponentFactory(UiComponentType.VALUE, valueModel);
-            return componentFactory.createComponent(id, valueModel);
-        }
-
-        val uiObject = UiObjectWkt.ofAdapterForCollection(super.getMetaModelContext(), adapter, variant);
-        uiObject.setContextBookmarkIfAny(contextBookmark);
-
-        // will use EntityLinkSimplePanelFactory as model is an EntityModel
-        val componentFactory = findComponentFactory(UiComponentType.ENTITY_LINK, uiObject);
-        final Component entityLink = opts.applyTo(
-                componentFactory.createComponent(id, uiObject));
-        return entityLink;
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/TitleColumnOptions.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/TitleColumnOptions.java
@@ -36,14 +36,14 @@ import lombok.Builder;
  * @since 2.0.0
  */
 @lombok.Value @Builder
-public class GenericTitleColumnOptions implements Serializable {
+public class TitleColumnOptions implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     @Builder.Default
     private final int maxElementTitleLength = -1;
 
-    private static final MetaDataKey<GenericTitleColumnOptions> KEY = new MetaDataKey<>() {
+    private static final MetaDataKey<TitleColumnOptions> KEY = new MetaDataKey<>() {
         private static final long serialVersionUID = 1L; };
 
     public <T extends Component> T applyTo(final T component) {
@@ -51,7 +51,7 @@ public class GenericTitleColumnOptions implements Serializable {
         return component;
     }
 
-    public static Optional<GenericTitleColumnOptions> lookupIn(final @Nullable Component component) {
+    public static Optional<TitleColumnOptions> lookupIn(final @Nullable Component component) {
         return Optional.ofNullable(component)
                 .map(comp->comp.getMetaData(KEY));
     }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
@@ -21,23 +21,19 @@ package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxt
 import java.util.List;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
-import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
 
 import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataRow;
 import org.apache.causeway.core.metamodel.interactions.managed.nonscalar.DataTableModel;
-import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
 import org.apache.causeway.viewer.wicket.ui.components.widgets.checkbox.ContainedToggleboxPanel;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 import lombok.val;
 
-public final class GenericToggleboxColumn
+public final class ToggleboxColumn
 extends GenericColumnAbstract {
 
     private static final long serialVersionUID = 1L;
@@ -52,11 +48,19 @@ extends GenericColumnAbstract {
 
     private IModel<DataTableModel> dataTableModelHolder;
 
-    public GenericToggleboxColumn(
+    public ToggleboxColumn(
             final MetaModelContext commonContext,
             final IModel<DataTableModel> dataTableModelHolder) {
         super(commonContext, "");
         this.dataTableModelHolder = dataTableModelHolder;
+    }
+
+    @Override
+    protected Component createCellComponent(
+            final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
+        val rowToggle = new ContainedToggleboxPanel(componentId, dataRowToggle);
+        rowToggles.add(rowToggle);
+        return rowToggle.setOutputMarkupId(true);
     }
 
     @Override
@@ -78,30 +82,8 @@ extends GenericColumnAbstract {
 
     private final List<ContainedToggleboxPanel> rowToggles = _Lists.newArrayList();
 
-    @Override
-    public void populateItem(
-            final Item<ICellPopulator<DataRow>> cellItem,
-            final String componentId,
-            final IModel<DataRow> rowModel) {
-
-        Wkt.cssAppend(cellItem, "togglebox-column");
-
-        final MarkupContainer row = cellItem.getParent().getParent();
-        row.setOutputMarkupId(true);
-        val rowToggle = new ContainedToggleboxPanel(
-                componentId,
-                ((DataRowWkt)rowModel).getDataRowToggle());
-        rowToggles.add(rowToggle);
-        rowToggle.setOutputMarkupId(true);
-        cellItem.add(rowToggle);
-    }
-
     public void removeToggles() {
         rowToggles.clear();
     }
-
-
-
-
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/entity/icontitle/EntityIconAndTitlePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/entity/icontitle/EntityIconAndTitlePanel.java
@@ -34,7 +34,7 @@ import org.apache.causeway.viewer.wicket.model.models.ObjectAdapterModel;
 import org.apache.causeway.viewer.wicket.model.models.PageType;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.model.util.PageParameterUtils;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericTitleColumnOptions;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumnOptions;
 import org.apache.causeway.viewer.wicket.ui.panels.PanelAbstract;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 import org.apache.causeway.viewer.wicket.ui.util.WktComponents;
@@ -212,7 +212,7 @@ extends PanelAbstract<ManagedObject, ObjectAdapterModel> {
         /* Allows any higher-order component factory to customize appearance,
          * if the context requires it.
          * Eg. don't suppress titles for tables that have no property columns. */
-        final int maxTitleLengthOverride = GenericTitleColumnOptions.lookupIn(this)
+        final int maxTitleLengthOverride = TitleColumnOptions.lookupIn(this)
             .map(opts->opts.getMaxElementTitleLength())
             .orElse(-1);
         if(maxTitleLengthOverride>-1) {

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/entity/icontitle/EntityIconAndTitlePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/entity/icontitle/EntityIconAndTitlePanel.java
@@ -34,7 +34,7 @@ import org.apache.causeway.viewer.wicket.model.models.ObjectAdapterModel;
 import org.apache.causeway.viewer.wicket.model.models.PageType;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.model.util.PageParameterUtils;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumnOptions;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ColumnAbbreviationOptions;
 import org.apache.causeway.viewer.wicket.ui.panels.PanelAbstract;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 import org.apache.causeway.viewer.wicket.ui.util.WktComponents;
@@ -212,7 +212,7 @@ extends PanelAbstract<ManagedObject, ObjectAdapterModel> {
         /* Allows any higher-order component factory to customize appearance,
          * if the context requires it.
          * Eg. don't suppress titles for tables that have no property columns. */
-        final int maxTitleLengthOverride = TitleColumnOptions.lookupIn(this)
+        final int maxTitleLengthOverride = ColumnAbbreviationOptions.lookupIn(this)
             .map(opts->opts.getMaxElementTitleLength())
             .orElse(-1);
         if(maxTitleLengthOverride>-1) {

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/checkbox/ContainedToggleboxPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/checkbox/ContainedToggleboxPanel.java
@@ -24,7 +24,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.danekja.java.util.function.serializable.SerializableBiConsumer;
 
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericToggleboxColumn.BulkToggle;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn.BulkToggle;
 import org.apache.causeway.viewer.wicket.ui.panels.PanelAbstract;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/entitysimplelink/EntityLinkSimplePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/entitysimplelink/EntityLinkSimplePanel.java
@@ -32,7 +32,7 @@ import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.viewer.commons.model.components.UiComponentType;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumnOptions;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ColumnAbbreviationOptions;
 import org.apache.causeway.viewer.wicket.ui.components.widgets.formcomponent.CancelHintRequired;
 import org.apache.causeway.viewer.wicket.ui.components.widgets.formcomponent.FormComponentPanelAbstract;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
@@ -84,7 +84,7 @@ implements CancelHintRequired  {
                     .createComponent(ID_ENTITY_ICON_AND_TITLE, objectModelForLink);
 
             // propagate options (if any) from this component to the child component, that's using them
-            TitleColumnOptions.lookupIn(this)
+            ColumnAbbreviationOptions.lookupIn(this)
                 .ifPresent(opts->opts.applyTo(component));
 
             addOrReplace(component);

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/entitysimplelink/EntityLinkSimplePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/entitysimplelink/EntityLinkSimplePanel.java
@@ -32,7 +32,7 @@ import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.viewer.commons.model.components.UiComponentType;
-import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.GenericTitleColumnOptions;
+import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumnOptions;
 import org.apache.causeway.viewer.wicket.ui.components.widgets.formcomponent.CancelHintRequired;
 import org.apache.causeway.viewer.wicket.ui.components.widgets.formcomponent.FormComponentPanelAbstract;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
@@ -84,7 +84,7 @@ implements CancelHintRequired  {
                     .createComponent(ID_ENTITY_ICON_AND_TITLE, objectModelForLink);
 
             // propagate options (if any) from this component to the child component, that's using them
-            GenericTitleColumnOptions.lookupIn(this)
+            TitleColumnOptions.lookupIn(this)
                 .ifPresent(opts->opts.applyTo(component));
 
             addOrReplace(component);


### PR DESCRIPTION
- [x] let metamodel consider `OneToManyAssociation`s as table column candidates
- [x] adopt the _Excel_ export model to handle plural cells
- [x] adopt _Wicket Viewer_'s `CollectionContentsAsAjaxTablePanel` to render plural cells
- [ ] doc/site update -> deferred
- [ ] demo update -> deferred