### PR TITLE
CAUSEWAY-3598 logical type names of an object also be defined as alias

### DIFF
--- a/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
+++ b/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
@@ -62,6 +62,8 @@ import org.springframework.validation.annotation.Validated;
 
 import org.apache.causeway.applib.CausewayModuleApplib;
 import org.apache.causeway.applib.annotation.ActionLayout;
+import org.apache.causeway.applib.annotation.DomainObject;
+import org.apache.causeway.applib.annotation.DomainService;
 import org.apache.causeway.applib.annotation.Introspection.IntrospectionPolicy;
 import org.apache.causeway.applib.annotation.LabelPosition;
 import org.apache.causeway.applib.annotation.PromptStyle;
@@ -1582,6 +1584,18 @@ public class CausewayConfiguration {
                  * </p>
                  */
                 private boolean explicitLogicalTypeNames = false;
+
+                /**
+                 * Allows logical type name in {@link Named} also be included in the list of {@link DomainObject#aliased()}
+                 * or {@link DomainService#aliased()}.
+                 *
+                 * <p>
+                 *     It is <i>highly advisable</i> to leave this disabled. This option is meant as a practical way to
+                 *     enable to transition from old names to new logical type names. Especially when you have a large
+                 *     number of files that have to migrated and you want to do the migration in incremental steps.
+                 * </p>
+                 */
+                private boolean allowLogicalTypeNameAsAlias = false;
 
                 private final JaxbViewModel jaxbViewModel = new JaxbViewModel();
                 @Data

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/object/domainobject/DomainObjectAnnotationFacetFactoryTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/object/domainobject/DomainObjectAnnotationFacetFactoryTest.java
@@ -22,6 +22,15 @@ import java.util.UUID;
 
 import javax.inject.Named;
 
+import lombok.val;
+
+import org.apache.causeway.core.metamodel._testing.MetaModelContext_forTesting;
+import org.apache.causeway.core.metamodel.facets.AbstractTestWithMetaModelContext;
+import org.apache.causeway.core.metamodel.progmodel.ProgrammingModelInitFilterDefault;
+import org.apache.causeway.core.metamodel.progmodels.dflt.ProgrammingModelFacetsJava11;
+import org.apache.causeway.core.metamodel.specloader.specimpl.IntrospectionState;
+import org.apache.causeway.core.metamodel.specloader.validator.ValidationFailures;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.causeway.applib.annotation.Bounding;
 import org.apache.causeway.applib.annotation.DomainObject;
+import org.apache.causeway.applib.annotation.DomainService;
 import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.applib.mixins.system.HasInteractionId;
 import org.apache.causeway.core.config.metamodel.facets.DomainObjectConfigOptions;
@@ -657,5 +667,90 @@ extends FacetFactoryTestAbstract {
 
     }
 
+    public static class Alias extends AbstractTestWithMetaModelContext {
+        DomainObjectAnnotationFacetFactory facetFactory;
 
+        @Named("object.name")
+        @DomainObject(aliased = {"object.name", "object.alias"})
+        class DomainObjectWithAliases {
+        }
+
+        @Named("service.name")
+        @DomainService(aliased = {"service.name", "service.alias"})
+        class DomainServiceWithAliases {
+        }
+
+        @Test
+        public void testValidationDomainObjectWithAliasesConfigured() {
+            metaModelContext = MetaModelContext_forTesting.builder()
+                    .programmingModelFactory(mmc -> {
+                        val progModel = new ProgrammingModelFacetsJava11(mmc);
+                        facetFactory.refineProgrammingModel(progModel);
+                        progModel.init(new ProgrammingModelInitFilterDefault());
+                        return progModel;
+                    })
+                    .build();
+            getConfiguration().getCore().getMetaModel().getValidator().setAllowLogicalTypeNameAsAlias(true);
+            facetFactory = new DomainObjectAnnotationFacetFactory(getMetaModelContext());
+            ((MetaModelContext_forTesting) getMetaModelContext()).getProgrammingModel();//kicks off the programming model factory
+
+            getMetaModelContext().getSpecificationLoader().loadSpecification(DomainObjectWithAliases.class, IntrospectionState.FULLY_INTROSPECTED);
+            ValidationFailures validationFailures = getMetaModelContext().getSpecificationLoader().getOrAssessValidationResult();
+            assertFalse(validationFailures.hasFailures());
+        }
+
+        @Test
+        public void testValidationDomainServiceWithAliasesConfigured() {
+            metaModelContext = MetaModelContext_forTesting.builder()
+                    .programmingModelFactory(mmc -> {
+                        val progModel = new ProgrammingModelFacetsJava11(mmc);
+                        facetFactory.refineProgrammingModel(progModel);
+                        progModel.init(new ProgrammingModelInitFilterDefault());
+                        return progModel;
+                    })
+                    .build();
+            getConfiguration().getCore().getMetaModel().getValidator().setAllowLogicalTypeNameAsAlias(true);
+            facetFactory = new DomainObjectAnnotationFacetFactory(getMetaModelContext());
+            ((MetaModelContext_forTesting) getMetaModelContext()).getProgrammingModel();//kicks off the programming model factory
+
+            getMetaModelContext().getSpecificationLoader().loadSpecification(DomainServiceWithAliases.class, IntrospectionState.FULLY_INTROSPECTED);
+            ValidationFailures validationFailures = getMetaModelContext().getSpecificationLoader().getOrAssessValidationResult();
+            assertFalse(validationFailures.hasFailures());
+        }
+        @Test
+        public void testValidationDomainObjectWithAliasesDefault() {
+            metaModelContext = MetaModelContext_forTesting.builder()
+                    .programmingModelFactory(mmc -> {
+                        val progModel = new ProgrammingModelFacetsJava11(mmc);
+                        facetFactory.refineProgrammingModel(progModel);
+                        progModel.init(new ProgrammingModelInitFilterDefault());
+                        return progModel;
+                    })
+                    .build();
+            facetFactory = new DomainObjectAnnotationFacetFactory(getMetaModelContext());
+            ((MetaModelContext_forTesting) getMetaModelContext()).getProgrammingModel();//kicks off the programming model factory
+
+            getMetaModelContext().getSpecificationLoader().loadSpecification(DomainObjectWithAliases.class, IntrospectionState.FULLY_INTROSPECTED);
+            ValidationFailures validationFailures = getMetaModelContext().getSpecificationLoader().getOrAssessValidationResult();
+            assertTrue(validationFailures.hasFailures());
+        }
+
+        @Test
+        public void testValidationDomainServiceWithAliasesDefault() {
+            metaModelContext = MetaModelContext_forTesting.builder()
+                    .programmingModelFactory(mmc -> {
+                        val progModel = new ProgrammingModelFacetsJava11(mmc);
+                        facetFactory.refineProgrammingModel(progModel);
+                        progModel.init(new ProgrammingModelInitFilterDefault());
+                        return progModel;
+                    })
+                    .build();
+            facetFactory = new DomainObjectAnnotationFacetFactory(getMetaModelContext());
+            ((MetaModelContext_forTesting) getMetaModelContext()).getProgrammingModel();//kicks off the programming model factory
+
+            getMetaModelContext().getSpecificationLoader().loadSpecification(DomainServiceWithAliases.class, IntrospectionState.FULLY_INTROSPECTED);
+            ValidationFailures validationFailures = getMetaModelContext().getSpecificationLoader().getOrAssessValidationResult();
+            assertTrue(validationFailures.hasFailures());
+        }
+    }
 }


### PR DESCRIPTION
added support for allowing logical type names of an object also be defined as alias