### PR TITLE
CAUSEWAY-3609: adds an SPI to allow JDO object store's impl of auditing

### DIFF
--- a/persistence/commons/src/main/java/org/apache/causeway/persistence/jpa/integration/changetracking/EntityChangeTrackerDefault.java
+++ b/persistence/commons/src/main/java/org/apache/causeway/persistence/jpa/integration/changetracking/EntityChangeTrackerDefault.java
@@ -61,6 +61,7 @@ import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.core.metamodel.object.MmEntityUtils;
 import org.apache.causeway.core.metamodel.services.objectlifecycle.HasEnlistedEntityPropertyChanges;
+import org.apache.causeway.core.metamodel.services.objectlifecycle.PreAndPostValue;
 import org.apache.causeway.core.metamodel.services.objectlifecycle.PropertyChangeRecord;
 import org.apache.causeway.core.metamodel.services.objectlifecycle.PropertyChangeRecordId;
 import org.apache.causeway.core.transaction.changetracking.EntityChangeTracker;
@@ -108,6 +109,7 @@ implements
     private final EntityPropertyChangePublisher entityPropertyChangePublisher;
     private final EntityChangesPublisher entityChangesPublisher;
     private final Provider<InteractionProvider> interactionProviderProvider;
+    private final PreAndPostValueEvaluatorService preAndPostValueEvaluatorService;
 
     /**
      * Contains a record for every objectId/propertyId that was changed.
@@ -162,13 +164,16 @@ implements
                         rec.withPostValueSetToCurrent();
                     }
                 })
-                .filter(managedProperty->managedProperty.getPreAndPostValue().shouldPublish())
+                .filter(managedProperty-> shouldPublish(managedProperty.getPreAndPostValue()))
                 .collect(_Sets.toUnmodifiable());
 
         enlistedPropertyChangeRecordsById.clear();
 
         return records;
+    }
 
+    private boolean shouldPublish(PreAndPostValue preAndPostValue) {
+        return preAndPostValueEvaluatorService.differ(preAndPostValue);
     }
 
     private boolean isEntityExcludedForChangePublishing(final ManagedObject entity) {

--- a/persistence/commons/src/main/java/org/apache/causeway/persistence/jpa/integration/changetracking/PreAndPostValueEvaluatorService.java
+++ b/persistence/commons/src/main/java/org/apache/causeway/persistence/jpa/integration/changetracking/PreAndPostValueEvaluatorService.java
@@ -15,26 +15,16 @@
  *  KIND, either express or implied.  See the License for the
  *  specific language governing permissions and limitations
  *  under the License.
+ *
  */
-package org.apache.causeway.persistence.commons;
+package org.apache.causeway.persistence.jpa.integration.changetracking;
 
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
+import org.apache.causeway.core.metamodel.services.objectlifecycle.PreAndPostValue;
 
-import org.apache.causeway.core.runtime.CausewayModuleCoreRuntime;
-import org.apache.causeway.persistence.jpa.integration.changetracking.EntityChangeTrackerDefault;
-import org.apache.causeway.persistence.jpa.integration.changetracking.PreAndPostValueEvaluatorServiceDefault;
-
-@Configuration
-@Import({
-        // modules
-        CausewayModuleCoreRuntime.class,
-
-        // @Service's
-        EntityChangeTrackerDefault.class,
-        EntityChangeTrackerDefault.TransactionSubscriber.class,
-        PreAndPostValueEvaluatorServiceDefault.class,
-})
-public class CausewayModulePersistenceCommons {
-
+/**
+ * Defines an SPI to determine whether the pre- and post values in the {@link PreAndPostValue} are actually
+ * different (and so should be published).
+ */
+public interface PreAndPostValueEvaluatorService {
+    boolean differ(PreAndPostValue preAndPostValue);
 }

--- a/persistence/commons/src/main/java/org/apache/causeway/persistence/jpa/integration/changetracking/PreAndPostValueEvaluatorServiceDefault.java
+++ b/persistence/commons/src/main/java/org/apache/causeway/persistence/jpa/integration/changetracking/PreAndPostValueEvaluatorServiceDefault.java
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.apache.causeway.persistence.jpa.integration.changetracking;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import org.apache.causeway.applib.annotation.InteractionScope;
+import org.apache.causeway.applib.annotation.PriorityPrecedence;
+import org.apache.causeway.core.metamodel.services.objectlifecycle.PreAndPostValue;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@Named("causeway.persistence.commons.PreAndPostValueEvaluatorServiceDefault")
+@Priority(PriorityPrecedence.LATE)
+@Qualifier("default")
+@InteractionScope   // see note above regarding this
+@RequiredArgsConstructor(onConstructor_ = {@Inject})
+@Log4j2
+public class PreAndPostValueEvaluatorServiceDefault implements PreAndPostValueEvaluatorService {
+
+    @Override
+    public boolean differ(PreAndPostValue preAndPostValue) {
+        return preAndPostValue.shouldPublish();
+    }
+}

--- a/persistence/jdo/datanucleus/src/main/java/org/apache/causeway/persistence/jdo/datanucleus/CausewayModulePersistenceJdoDatanucleus.java
+++ b/persistence/jdo/datanucleus/src/main/java/org/apache/causeway/persistence/jdo/datanucleus/CausewayModulePersistenceJdoDatanucleus.java
@@ -27,6 +27,7 @@ import javax.sql.DataSource;
 
 import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
 import org.datanucleus.metadata.PersistenceUnitMetaData;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -44,6 +45,7 @@ import org.apache.causeway.core.config.beans.aoppatch.TransactionInterceptorFact
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
 import org.apache.causeway.core.metamodel.services.objectlifecycle.ObjectLifecyclePublisher;
 import org.apache.causeway.persistence.jdo.datanucleus.changetracking.JdoLifecycleListener;
+import org.apache.causeway.persistence.jdo.datanucleus.changetracking.PreAndPostValueEvaluatorServiceJdo;
 import org.apache.causeway.persistence.jdo.datanucleus.config.DatanucleusSettings;
 import org.apache.causeway.persistence.jdo.datanucleus.dialect.DnJdoDialect;
 import org.apache.causeway.persistence.jdo.datanucleus.entities.DnEntityStateProvider;
@@ -111,6 +113,7 @@ import lombok.extern.log4j.Log4j2;
     // @Service's
     JdoSupportServiceDefault.class,
     JdoObjectNotFoundRecognizer.class,
+    PreAndPostValueEvaluatorServiceJdo.class,
 
 })
 @EnableConfigurationProperties(DatanucleusSettings.class)

--- a/persistence/jdo/datanucleus/src/main/java/org/apache/causeway/persistence/jdo/datanucleus/changetracking/PreAndPostValueEvaluatorServiceJdo.java
+++ b/persistence/jdo/datanucleus/src/main/java/org/apache/causeway/persistence/jdo/datanucleus/changetracking/PreAndPostValueEvaluatorServiceJdo.java
@@ -1,0 +1,99 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.apache.causeway.persistence.jdo.datanucleus.changetracking;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.datanucleus.enhancement.Persistable;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import org.apache.causeway.applib.annotation.InteractionScope;
+import org.apache.causeway.applib.annotation.PriorityPrecedence;
+import org.apache.causeway.core.metamodel.services.objectlifecycle.PreAndPostValue;
+import org.apache.causeway.core.metamodel.services.objectlifecycle.PropertyValuePlaceholder;
+import org.apache.causeway.persistence.jdo.datanucleus.entities.DnOidStoreAndRecoverHelper;
+import org.apache.causeway.persistence.jpa.integration.changetracking.PreAndPostValueEvaluatorService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@Named("causeway.persistence.jdo.PreAndPostValueEvaluatorServiceJdo")
+@Priority(PriorityPrecedence.MIDPOINT) // before the default
+@Qualifier("jdo")
+@InteractionScope   // see note above regarding this
+@RequiredArgsConstructor(onConstructor_ = {@Inject})
+@Log4j2
+public class PreAndPostValueEvaluatorServiceJdo implements PreAndPostValueEvaluatorService {
+
+    @Override
+    public boolean differ(PreAndPostValue papv) {
+
+        // don't audit objects that were created and then immediately deleted within the same xactn
+        if (papv.getPre() == PropertyValuePlaceholder.NEW
+                && papv.getPost() == PropertyValuePlaceholder.DELETED) {
+            return false;
+        }
+        // but do always audit objects that have just been created or deleted
+        if (papv.getPre() == PropertyValuePlaceholder.NEW
+                || papv.getPost() == PropertyValuePlaceholder.DELETED) {
+            return true;
+        }
+        if (papv.getPre() instanceof Persistable) {
+            Persistable prePersistable = (Persistable) papv.getPre();
+
+            if (!(papv.getPost() instanceof Persistable)) {
+                // must be different, so publish
+                return true;
+            }
+            Persistable postPersistable = ((Persistable) papv.getPost());
+
+            Optional<String> preOidIfAny = DnOidStoreAndRecoverHelper.forEntity(prePersistable).recoverOid();
+            Optional<String> postOidIfAny = DnOidStoreAndRecoverHelper.forEntity(postPersistable).recoverOid();
+
+            if (preOidIfAny.isPresent() || postOidIfAny.isPresent()) {
+                // at least one of the Persistables is hollow
+                return !Objects.equals(preOidIfAny, postOidIfAny);
+            }
+
+            // neither of the Persistables is hollow; should be safe to fall through.
+
+        } else {
+
+            if (papv.getPost() instanceof Persistable) {
+                // must be different, so publish
+                return true;
+            }
+
+            // should be safe to fall through.
+        }
+
+        // else - for updated objects - audit only if the property value has changed
+        return !Objects.equals(papv.getPre(), papv.getPost());
+    }
+
+}


### PR DESCRIPTION
(ie EntityChangeTracker) to fine-tune whether an audit record needs to be published.  This works by overriding the default impl of PreAndPostValue, taking into account whether either the pre or the post is a Persistable, and if so whether it is also hollow for some reason