### PR TITLE
CAUSEWAY-3575: adds unbound/missing properties or collections

### DIFF
--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/services/grid/bootstrap/GridSystemServiceBootstrap.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/services/grid/bootstrap/GridSystemServiceBootstrap.java
@@ -18,8 +18,10 @@
  */
 package org.apache.causeway.core.metamodel.services.grid.bootstrap;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -311,9 +313,16 @@ extends GridSystemServiceAbstract<BSGrid> {
                 val fieldSet = gridModel.getFieldSetForUnreferencedPropertiesRef();
                 if(fieldSet != null) {
                     unboundPropertyIds.removeAll(unboundMetadataContributingIds);
+
+                    // add unbound properties alphabetically to fieldset
+                    List<String> sortedUnboundPropertyIds =
+                            unboundPropertyIds.stream()
+                                .sorted()
+                                .collect(Collectors.toList());
+
                     addPropertiesTo(
                             fieldSet,
-                            unboundPropertyIds,
+                            sortedUnboundPropertyIds,
                             layoutDataFactory::createPropertyLayoutData,
                             propertyLayoutDataById::put);
                 }
@@ -331,13 +340,12 @@ extends GridSystemServiceAbstract<BSGrid> {
         }
 
         if(!missingCollectionIds.isEmpty()) {
-            final List<OneToManyAssociation> sortedCollections =
-                    _Lists.map(missingCollectionIds, oneToManyAssociationById::get);
 
-            sortedCollections.sort(ObjectMember.Comparators.byMemberOrderSequence(false));
-
+            // add missing collections alphabetically to either tab group or column
             final List<String> sortedMissingCollectionIds =
-                    _Lists.map(sortedCollections, ObjectAssociation::getId);
+                    missingCollectionIds.stream()
+                            .sorted()
+                            .collect(Collectors.toList());
 
             final BSTabGroup bsTabGroup = gridModel.getTabGroupForUnreferencedCollectionsRef();
             if(bsTabGroup != null) {

--- a/regressiontests/stable-interact/src/test/java/org/apache/causeway/testdomain/interact/CollectionInteractionTest.java
+++ b/regressiontests/stable-interact/src/test/java/org/apache/causeway/testdomain/interact/CollectionInteractionTest.java
@@ -101,7 +101,7 @@ class CollectionInteractionTest extends InteractionTestAbstract {
                 testerFactory.collectionTester(InteractionDemo.class, "items", Where.ANYWHERE)
                 .tableTester();
 
-        tableTester.assertColumnNames(List.of("Name", "Date"));
+        tableTester.assertColumnNames(List.of("Date", "Name"));
 
     }
 


### PR DESCRIPTION
in alphabetical order rather than according to their sequence.  Because the sequence (independent of its group) is hard to reason about