### PR TITLE
CAUSEWAY-3641: DataTableInteractive#Memento don't require Executions on Deserialization

### DIFF
--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 import org.springframework.lang.Nullable;
 
@@ -47,7 +46,6 @@ import org.apache.causeway.core.metamodel.interactions.VisibilityContext;
 import org.apache.causeway.core.metamodel.interactions.managed.ActionInteraction;
 import org.apache.causeway.core.metamodel.interactions.managed.CollectionInteraction;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction;
-import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction.MementoForArgs;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedCollection;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedMember;
 import org.apache.causeway.core.metamodel.interactions.managed.MultiselectChoices;
@@ -69,12 +67,12 @@ implements MultiselectChoices {
     // -- FACTORIES
 
     public static DataTableInteractive empty(final ManagedMember managedMember, final Where where) {
-        return new DataTableInteractive(managedMember, where, Can::empty);
+        return new DataTableInteractive(managedMember, where, Can.empty());
     }
 
     public static DataTableInteractive forCollection(
             final ManagedCollection managedCollection) {
-        return new DataTableInteractive(managedCollection, managedCollection.getWhere(), ()->
+        return new DataTableInteractive(managedCollection, managedCollection.getWhere(),
             managedCollection
             .streamElements()
             .collect(Can.toCan()));
@@ -86,7 +84,7 @@ implements MultiselectChoices {
             final ManagedObject actionResult) {
 
         if(actionResult==null) {
-            new DataTableInteractive(managedAction, managedAction.getWhere(), Can::empty);
+            new DataTableInteractive(managedAction, managedAction.getWhere(), Can.empty());
         }
         if(!(actionResult instanceof PackedManagedObject)) {
             throw _Exceptions.unexpectedCodeReach();
@@ -95,8 +93,7 @@ implements MultiselectChoices {
         val elements = ((PackedManagedObject)actionResult).unpack();
         elements.forEach(ManagedObject::getBookmark);
 
-        return new DataTableInteractive(managedAction, managedAction.getWhere(),
-                ()->elements);
+        return new DataTableInteractive(managedAction, managedAction.getWhere(), elements);
     }
 
     // -- CONSTRUCTION
@@ -118,13 +115,13 @@ implements MultiselectChoices {
             // we need access to the owner in support of imperative title and referenced column detection
             final ManagedMember managedMember,
             final Where where,
-            final Supplier<Can<ManagedObject>> elementSupplier) {
+            final Can<ManagedObject> elements) {
 
         this.managedMember = managedMember;
         this.where = where;
 
-        //dataElements = _Observables.lazy(elementSupplier);
-        dataElements = _Observables.lazy(()->elementSupplier.get().map(
+        //dataElements = _Observables.lazy(()->elements);
+        dataElements = _Observables.lazy(()->elements.map(
             MetaModelContext.instanceElseFail()::injectServicesInto));
 
         searchArgument = _Bindables.forValue(null);
@@ -261,7 +258,7 @@ implements MultiselectChoices {
 
     // -- EXPORT
 
-    public DataTable export() {
+    public DataTable exportFiltered() {
         return new DataTable(getElementType(),
                 getTitle().getValue(),
                 getDataColumns().getValue()
@@ -272,10 +269,18 @@ implements MultiselectChoices {
                     .collect(Can.toCan()));
     }
 
+    public DataTable exportAll() {
+        return new DataTable(getElementType(),
+                getTitle().getValue(),
+                getDataColumns().getValue()
+                    .map(DataColumn::getAssociationMetaModel),
+                getDataElements().getValue());
+    }
+
     // -- MEMENTO
 
-    public Memento getMemento(final @Nullable ManagedAction.MementoForArgs argsMemento) {
-        return Memento.create(this, argsMemento);
+    public Memento getMemento() {
+        return Memento.create(this);
     }
 
     /**
@@ -297,19 +302,18 @@ implements MultiselectChoices {
         private static final long serialVersionUID = 1L;
 
         static Memento create(
-                final @Nullable DataTableInteractive table,
-                final @Nullable MementoForArgs argsMemento) {
-            val managedMember = table.managedMember;
+                final @Nullable DataTableInteractive tableInteractive) {
+            val managedMember = tableInteractive.managedMember;
 
             return new Memento(
                     managedMember.getIdentifier(),
-                    table.where,
-                    argsMemento);
+                    tableInteractive.where,
+                    tableInteractive.exportAll());
         }
 
-        private final Identifier featureId;
-        private final Where where;
-        private final MementoForArgs argsMemento;
+        private final @NonNull Identifier featureId;
+        private final @NonNull Where where;
+        private final @NonNull DataTable dataTable;
 
         public DataTableInteractive getDataTableModel(final ManagedObject owner) {
 
@@ -320,21 +324,14 @@ implements MultiselectChoices {
 
             val memberId = featureId.getMemberLogicalName();
 
-            if(featureId.getType().isPropertyOrCollection()) {
-                // bypass domain events
-                val collInteraction = CollectionInteraction.start(owner, memberId, where);
-                val managedColl = collInteraction.getManagedCollection().orElseThrow();
-                // invocation bypassing domain events (pass-through)
-                return new DataTableInteractive(managedColl, where, ()->
-                    managedColl.streamElements(InteractionInitiatedBy.PASS_THROUGH).collect(Can.toCan()));
-            }
-            val actionInteraction = ActionInteraction.start(owner, memberId, where);
-            val managedAction = actionInteraction.getManagedActionElseFail();
-            val args = argsMemento.getArgumentList(managedAction.getMetaModel());
-            // invocation bypassing domain events (pass-through)
-            val actionResult = managedAction.invoke(args, InteractionInitiatedBy.PASS_THROUGH)
-                    .getSuccessElseFail();
-            return forAction(managedAction, args, actionResult);
+            final ManagedMember managedMember = featureId.getType().isPropertyOrCollection()
+                    ? CollectionInteraction.start(owner, memberId, where)
+                        .getManagedCollection().orElseThrow()
+                    : ActionInteraction.start(owner, memberId, where)
+                        .getManagedActionElseFail();
+
+            return new DataTableInteractive(managedMember, where,
+                    dataTable.streamDataElements().collect(Can.toCan()));
         }
     }
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -67,7 +67,7 @@ implements
                 args,
                 actionResult);
 
-        val tableMemento = table.getMemento(managedAction.getMementoForArgs(args));
+        val tableMemento = table.getMemento();
 
         val model = new DataTableModelWkt(
                 bookmarkedObjectModel, actMetaModel.getFeatureIdentifier(), tableMemento);
@@ -85,7 +85,7 @@ implements
                 ManagedCollection
                 .of(bookmarkedObjectModel.getObject(), collMetaModel, Where.NOT_SPECIFIED));
 
-        val tableMemento = table.getMemento(null);
+        val tableMemento = table.getMemento();
 
         val model = new DataTableModelWkt(
                 bookmarkedObjectModel, collMetaModel.getFeatureIdentifier(), tableMemento);

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/export/CollectionContentsAsExportFactory.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/export/CollectionContentsAsExportFactory.java
@@ -113,7 +113,7 @@ implements CollectionContentsAsFactory {
         public File getObject() {
             val tempFile = File.createTempFile(CollectionContentsAsExportFactory.class.getCanonicalName(), fileName);
             Try.run(()->
-                exporter().createExport(model.getDataTableModel().export(), tempFile))
+                exporter().createExport(model.getDataTableModel().exportFiltered(), tempFile))
             .ifFailure(__->{
                 Files.remove(tempFile); // cleanup after sad case
             })


### PR DESCRIPTION
- [x] Use the (now) serializable `DataTable` to model table data
- [ ] Invent some freeze mechanism for `DataTable`, that is, once we have the cell data, don't require to recompute (via executions)

As we do want to pave the way for a generic search field, we need all the table rows, hence table paging is modeled as a view into the **full** `DataTable`.