### PR TITLE
Fixed 4 flaky tests detected by NonDex

### DIFF
--- a/api/applib/pom.xml
+++ b/api/applib/pom.xml
@@ -106,6 +106,11 @@
 			<artifactId>causeway-core-internaltestsupport</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+        </dependency>
 
     </dependencies>
 

--- a/api/applib/src/test/java/org/apache/causeway/applib/layout/menubars/bootstrap/BSMenuBars_roundtrip_Test.java
+++ b/api/applib/src/test/java/org/apache/causeway/applib/layout/menubars/bootstrap/BSMenuBars_roundtrip_Test.java
@@ -29,6 +29,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.apache.causeway.applib.layout.component.ServiceActionLayoutData;
 import org.apache.causeway.applib.services.jaxb.JaxbService;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import java.io.ByteArrayInputStream;
+import org.xml.sax.InputSource;
 
 public class BSMenuBars_roundtrip_Test {
 
@@ -78,7 +83,14 @@ public class BSMenuBars_roundtrip_Test {
         // then
         String xml2 = jaxbService.toXml(menuBars2);
 
-        assertThat(xml, is(equalTo(xml2)));
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document doc1 = db.parse(new InputSource(new ByteArrayInputStream(xml.getBytes("utf-8"))));
+        Document doc2 = db.parse(new InputSource(new ByteArrayInputStream(xml2.getBytes("utf-8"))));
+        doc1.normalizeDocument();
+        doc2.normalizeDocument();
+        assertThat(doc1.isEqualNode(doc2), is(true));
 
     }
 

--- a/api/applib/src/test/java/org/apache/causeway/applib/util/schema/CommonDtoUtils_Test.java
+++ b/api/applib/src/test/java/org/apache/causeway/applib/util/schema/CommonDtoUtils_Test.java
@@ -29,6 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.apache.causeway.schema.cmd.v2.MapDto;
 import org.apache.causeway.schema.common.v2.TypedTupleDto;
 import org.apache.causeway.schema.common.v2.ValueType;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -94,12 +96,12 @@ class CommonDtoUtils_Test {
                 + "{\"string\":\"sample\",\"type\":\"string\",\"name\":\"calendarName\"}],"
                 + "\"type\":\"org.apache.causeway.applib.util.schema.CommonDtoUtils_Test$CompositeSample\","
                 + "\"cardinality\":2}";
-
-        assertEquals(expectedJson, json);
-
+        JsonElement actual = JsonParser.parseString(json);
+        JsonElement expected = JsonParser.parseString(expectedJson);
+        assertEquals(actual.equals(expected), true);
         val compositeAfterRoundtrip = CommonDtoUtils.getCompositeValueFromJson(json);
-
-        assertEquals(expectedJson, CommonDtoUtils.getCompositeValueAsJson(compositeAfterRoundtrip));
+        JsonElement compositeJson = JsonParser.parseString(CommonDtoUtils.getCompositeValueAsJson(compositeAfterRoundtrip));
+        assertEquals(compositeJson.equals(expected), true);
 
     }
 

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/services/grid/GridXmlRoundtripTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/services/grid/GridXmlRoundtripTest.java
@@ -44,6 +44,11 @@ import org.apache.causeway.applib.services.jaxb.JaxbService;
 import org.apache.causeway.commons.internal.collections._Lists;
 import org.apache.causeway.commons.internal.collections._Maps;
 import org.apache.causeway.core.metamodel.MetaModelTestAbstract;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import java.io.ByteArrayInputStream;
+import org.xml.sax.InputSource;
 
 class GridXmlRoundtripTest
 extends MetaModelTestAbstract {
@@ -131,13 +136,17 @@ extends MetaModelTestAbstract {
         String xml = jaxbService.toXml(bsGrid,
                 _Maps.unmodifiable(Marshaller.JAXB_SCHEMA_LOCATION, schemaLocations));
         println(xml);
-
         BSGrid bsPageroundtripped = jaxbService.fromXml(BSGrid.class, xml);
         String xmlRoundtripped = jaxbService.toXml(bsPageroundtripped,
                 _Maps.unmodifiable(Marshaller.JAXB_SCHEMA_LOCATION, schemaLocations));
-        assertThat(xml, is(equalTo(xmlRoundtripped)));
-
-
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document doc1 = db.parse(new InputSource(new ByteArrayInputStream(xml.getBytes("utf-8"))));
+        Document doc2 = db.parse(new InputSource(new ByteArrayInputStream(xmlRoundtripped.getBytes("utf-8"))));
+        doc1.normalizeDocument();
+        doc2.normalizeDocument();
+        assertThat(doc1.isEqualNode(doc2), is(true));
         println("==========");
 
         dumpXsd(bsGrid);

--- a/testing/unittestsupport/applib/src/test/java/org/apache/causeway/testing/unittestsupport/applib/dom/pojo/PojoTester_broken_Test.java
+++ b/testing/unittestsupport/applib/src/test/java/org/apache/causeway/testing/unittestsupport/applib/dom/pojo/PojoTester_broken_Test.java
@@ -21,6 +21,8 @@ package org.apache.causeway.testing.unittestsupport.applib.dom.pojo;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 
 public class PojoTester_broken_Test {
 
@@ -41,13 +43,13 @@ public class PojoTester_broken_Test {
             this.lastName = lastName;
         }
     }
-    
+
     @Test
     public void strict_when_interference_between_properties() {
         Assertions.assertThatThrownBy(() -> {
-            PojoTester.create().exercise(new CustomerWithInterferingProperties());
-        }).isInstanceOf(AssertionFailedError.class)
-                .hasMessageContaining("firstName");
+                    PojoTester.create().exercise(new CustomerWithInterferingProperties());
+                }).isInstanceOf(AssertionFailedError.class)
+                .hasMessageMatching(".*(firstName|lastName).*");
     }
 
     public static class BrokenCustomer {


### PR DESCRIPTION
# Test1
```org.apache.causeway.applib.layout.menubars.bootstrap.BSMenuBars_roundtrip_Test#happyCase```
## Cause of error
This test was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```assertThat(xml, is(equalTo(xml2)));```. The flakiness was resulted from the indeterminant order of the bodies inside the XML strings. The storage of properties inside of BSMenuBars implemented ConcurrentHashMap. It is impossible to maintain the concurrency while keeping a fixed order of the elements. The resulting xml and xml2 strings from NonDex shuffling will therefore not match. The error messages:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.592 s <<< FAILURE! - in org.apache.causeway.core.metamodel.services.grid.GridXmlRoundtripTest
[ERROR] org.apache.causeway.core.metamodel.services.grid.GridXmlRoundtripTest.happy_case  Time elapsed: 1.559 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: is "<?xml version=\"1.0\" encoding=\"UTF-8\"?><bs:grid xmlns:bs=\"https://causeway.apache.org/applib/layout/grid/bootstrap3\" xmlns:cpt=\"https://causeway.apache.org/applib/layout/component\" xmlns:lnk=\"https://causeway.apache.org/applib/layout/links\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"https://causeway.apache.org/applib/layout/component https://causeway.apache.org/applib/layout/component/component.xsd https://causeway.apache.org/applib/layout/links https://causeway.apache.org/applib/layout/links/links.xsd https://causeway.apache.org/applib/layout/grid/bootstrap3 https://causeway.apache.org/applib/layout/grid/bootstrap3/bootstrap3.xsd\">\n    <bs:row>\n        <bs:col span=\"12\">\n            <cpt:domainObject/>\n            <cpt:action id=\"delete\"/>\n        </bs:col>\n    </bs:row>\n    <bs:row>\n        <bs:col span=\"12\">\n            <bs:tabGroup>\n                <bs:tab name=\"Common\">\n                    <bs:row>\n                        <bs:col span=\"6\">\n                            <cpt:fieldSet name=\"General\">\n                                <cpt:property dateRenderAdjustDays=\"0\">\n                                    <cpt:named>name</cpt:named>\n                                    <cpt:action id=\"updateName\"/>\n                                </cpt:property>\n                            </cpt:fieldSet>\n                        </bs:col>\n                        <bs:col span=\"6\">\n                            <cpt:collection id=\"similarTo\"/>\n                        </bs:col>\n                    </bs:row>\n                </bs:tab>\n            </bs:tabGroup>\n        </bs:col>\n    </bs:row>\n</bs:grid>\n"
     but: was "<?xml version=\"1.0\" encoding=\"UTF-8\"?><bs:grid xmlns:bs=\"https://causeway.apache.org/applib/layout/grid/bootstrap3\" xmlns:lnk=\"https://causeway.apache.org/applib/layout/links\" xmlns:cpt=\"https://causeway.apache.org/applib/layout/component\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"https://causeway.apache.org/applib/layout/component https://causeway.apache.org/applib/layout/component/component.xsd https://causeway.apache.org/applib/layout/links https://causeway.apache.org/applib/layout/links/links.xsd https://causeway.apache.org/applib/layout/grid/bootstrap3 https://causeway.apache.org/applib/layout/grid/bootstrap3/bootstrap3.xsd\">\n    <bs:row>\n        <bs:col span=\"12\">\n            <cpt:domainObject/>\n            <cpt:action id=\"delete\"/>\n        </bs:col>\n    </bs:row>\n    <bs:row>\n        <bs:col span=\"12\">\n            <bs:tabGroup>\n                <bs:tab name=\"Common\">\n                    <bs:row>\n                        <bs:col span=\"6\">\n                            <cpt:fieldSet name=\"General\">\n                                <cpt:property dateRenderAdjustDays=\"0\">\n                                    <cpt:named>name</cpt:named>\n                                    <cpt:action id=\"updateName\"/>\n                                </cpt:property>\n                            </cpt:fieldSet>\n                        </bs:col>\n                        <bs:col span=\"6\">\n                            <cpt:collection id=\"similarTo\"/>\n                        </bs:col>\n                    </bs:row>\n                </bs:tab>\n            </bs:tabGroup>\n        </bs:col>\n    </bs:row>\n</bs:grid>\n"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.apache.causeway.core.metamodel.services.grid.GridXmlRoundtripTest.happy_case(GridXmlRoundtripTest.java:162)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```
## Changes proposed 
Since the purpose of this test is to determine the the content inside of the XML but not the order, I normalized the raw XML into DOM structure and compared the content inside. This avoided the order matching issues.
# Test2
```org.apache.causeway.core.metamodel.services.grid.GridXmlRoundtripTest#happy_case```
## Cause of error
Similar as Test 1.
## Changes propesed
Same as Test 1.
# Test3
```org.apache.causeway.applib.util.schema.CommonDtoUtils_Test.roundtripOnComposites```
## Cause of error
This test was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```assertEquals(expectedJson, json);```. The flakiness was resulted from the indeterminant order of the components inside of the JSON string during the NonDex shuffling. The expected JSON string was defined with fixed pattern using string, and thus the actual JSON string will not match. The error messages:

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.728 s <<< FAILURE! - in org.apache.causeway.applib.util.schema.CommonDtoUtils_Test
[ERROR] org.apache.causeway.applib.util.schema.CommonDtoUtils_Test.roundtripOnComposites  Time elapsed: 0.696 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <{"elements":[{"long":123456,"type":"long","name":"epochMillis"},{"string":"sample","type":"string","name":"calendarName"}],"type":"org.apache.causeway.applib.util.schema.CommonDtoUtils_Test$CompositeSample","cardinality":2}> but was: <{"elements":[{"long":123456,"type":"long","name":"epochMillis"},{"string":"sample","type":"string","name":"calendarName"}],"cardinality":2,"type":"org.apache.causeway.applib.util.schema.CommonDtoUtils_Test$CompositeSample"}>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
        at org.apache.causeway.applib.util.schema.CommonDtoUtils_Test.roundtripOnComposites(CommonDtoUtils_Test.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[ERROR] Failures: 
[ERROR]   CommonDtoUtils_Test.roundtripOnComposites:104 expected: <{"elements":[{"long":123456,"type":"long","name":"epochMillis"},{"string":"sample","type":"string","name":"calendarName"}],"type":"org.apache.causeway.applib.util.schema.CommonDtoUtils_Test$CompositeSample","cardinality":2}> but was: <{"elements":[{"long":123456,"type":"long","name":"epochMillis"},{"string":"sample","type":"string","name":"calendarName"}],"cardinality":2,"type":"org.apache.causeway.applib.util.schema.CommonDtoUtils_Test$CompositeSample"}>
```
## Changes proposed 
Since the purpose of this test is to determine the the content inside of the JSON but not the order, I introduced the Gson dependency and converted the JSON strings into JSONElements. The .equals() comparison of JSONElements will ignore the order of the JSON object and JSON array.
#Test4
```org.apache.causeway.testing.unittestsupport.applib.dom.pojo.PojoTester_broken_Test#strict_when_interference_between_properties```
## Cause of error
This test was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```
Assertions.assertThatThrownBy(() -> {
            PojoTester.create().exercise(new CustomerWithInterferingProperties());
        }).isInstanceOf(AssertionFailedError.class)
                .hasMessageContaining("firstName");
```. The NonDex shuffling randomized the interferences of ```getLastName()```, ```SetLastName()```, ```getFirstName()```, ```SetFirstName()``` inside of ```CustomerWithInterferingProperties``` object. The test case only covers the "firstName" case. When the NonDex shuffling resulted in the interference of ```setlastName()``` and ```getFirstName```, the thrown exception should contain "lastName" but not "firstName". The error messages: 
```
[ERROR]   PojoTester_broken_Test.strict_when_interference_between_properties:50 
Expecting throwable message:
  "lastName: setLastName interferes with getFirstName"
to contain:
  "firstName"
but did not.
```
## Changes proposed 
The fix was rather simple. I used Regex expression and ```hasMessageMatching``` to cover both "firstName" and "lastName" cases.

# Debugging Environment
```
Apache Maven 3.8.4 (9b656c72d54e5bacbed989b64718c159fe39b537)
Maven home: /opt/maven/apache-maven-3.8.4
Java version: 17.0.8.1, vendor: Private Build, runtime: /usr/lib/jvm/java-17-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.4.0-167-generic", arch: "amd64", family: "unix"
```