### PR TITLE
Fixed 2 more flaky tests related to JSON order issue

### DIFF
--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/BlobValueSemanticsProviderTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/BlobValueSemanticsProviderTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.causeway.applib.value.Blob;
 import org.apache.causeway.core.metamodel.valuesemantics.BlobValueSemantics;
+import org.apache.causeway.commons.internal.testing._DocumentTester;
 
 class BlobValueSemanticsProviderTest
 extends ValueSemanticsProviderAbstractTestCase<Blob> {
@@ -50,9 +51,7 @@ extends ValueSemanticsProviderAbstractTestCase<Blob> {
 
     @Override
     protected void assertValueEncodesToJsonAs(final Blob a, final String json) {
-        assertEquals(
-                "{\"name\":\"myfile1.docx\",\"mimeType\":\"application/vnd.ms-word\",\"bytes\":\"AQIDBA==\"}",
-                json);
+        _DocumentTester.assertJsonEqualsIgnoreOrder("{\"name\":\"myfile1.docx\",\"mimeType\":\"application/vnd.ms-word\",\"bytes\":\"AQIDBA==\"}", json);
     }
 
 }

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/ClobValueSemanticsProviderTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/ClobValueSemanticsProviderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.causeway.core.metamodel.facets.value;
 
+import org.apache.causeway.commons.internal.testing._DocumentTester;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,9 +53,7 @@ extends ValueSemanticsProviderAbstractTestCase<Clob> {
 
     @Override
     protected void assertValueEncodesToJsonAs(final Clob a, final String json) {
-        assertEquals(
-                "{\"name\":\"myfile1.xml\",\"mimeType\":\"application/xml\",\"chars\":\"abcdef\"}",
-                json);
+        _DocumentTester.assertJsonEqualsIgnoreOrder("{\"name\":\"myfile1.xml\",\"mimeType\":\"application/xml\",\"chars\":\"abcdef\"}", json);
     }
 
 }


### PR DESCRIPTION
# Test1
```org.apache.causeway.core.metamodel.facets.value.BlobValueSemanticsProviderTest#valueSerializer(Format)[1]```
## Cause of error
This test was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was due to unmatched JSON string orders. The error messages:
```
[ERROR] Tests run: 10, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.561 s <<< FAILURE! - in org.apache.causeway.core.metamodel.facets.value.BlobValueSemanticsProviderTest
[ERROR] org.apache.causeway.core.metamodel.facets.value.BlobValueSemanticsProviderTest.valueSerializer(Format)[1]  Time elapsed: 0.192 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <{"name":"myfile1.docx","mimeType":"application/vnd.ms-word","bytes":"AQIDBA=="}> but was: <{"mimeType":"application/vnd.ms-word","bytes":"AQIDBA==","name":"myfile1.docx"}>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
        at org.apache.causeway.core.metamodel.facets.value.BlobValueSemanticsProviderTest.assertValueEncodesToJsonAs(BlobValueSemanticsProviderTest.java:53)
        at org.apache.causeway.core.metamodel.facets.value.BlobValueSemanticsProviderTest.assertValueEncodesToJsonAs(BlobValueSemanticsProviderTest.java:29)
        at org.apache.causeway.core.metamodel.facets.value.ValueSemanticsProviderAbstractTestCase.valueSerializer(ValueSemanticsProviderAbstractTestCase.java:131)

## Changes proposed 
Since the purpose of this test is to determine the the content inside of the JSON but not the order, I used the _DocumentTester helper method to assertJsonEqualIgnoreOrder
#Test2
```org.apache.causeway.core.metamodel.facets.value.ClobValueSemanticsProviderTest#valueSerializer(Format)[1]```
## Cause of error
Same issue above. The error messages: 
```
[ERROR] Tests run: 10, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.563 s <<< FAILURE! - in org.apache.causeway.core.metamodel.facets.value.ClobValueSemanticsProviderTest
[ERROR] org.apache.causeway.core.metamodel.facets.value.ClobValueSemanticsProviderTest.valueSerializer(Format)[1]  Time elapsed: 0.19 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <{"name":"myfile1.xml","mimeType":"application/xml","chars":"abcdef"}> but was: <{"chars":"abcdef","mimeType":"application/xml","name":"myfile1.xml"}>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
        at org.apache.causeway.core.metamodel.facets.value.ClobValueSemanticsProviderTest.assertValueEncodesToJsonAs(ClobValueSemanticsProviderTest.java:55)
        at org.apache.causeway.core.metamodel.facets.value.ClobValueSemanticsProviderTest.assertValueEncodesToJsonAs(ClobValueSemanticsProviderTest.java:29)
        at org.apache.causeway.core.metamodel.facets.value.ValueSemanticsProviderAbstractTestCase.valueSerializer(ValueSemanticsProviderAbstractTestCase.java:131)
```
## Changes proposed 
same as above.

# Debugging Environment
```
Apache Maven 3.8.4 (9b656c72d54e5bacbed989b64718c159fe39b537)
Maven home: /opt/maven/apache-maven-3.8.4
Java version: 17.0.8.1, vendor: Private Build, runtime: /usr/lib/jvm/java-17-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.4.0-167-generic", arch: "amd64", family: "unix"
```