### PR TITLE
Fixed 4 flaky tests for xml check

### DIFF
--- a/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_Abstract_IntegTest.java
+++ b/extensions/vw/pdfjs/metamodel/src/test/java/org/apache/causeway/extensions/pdfjs/metamodel/PdfjsViewer_Abstract_IntegTest.java
@@ -42,6 +42,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.TransactionStatus;
+import org.apache.causeway.commons.internal.testing._DocumentTester;
 
 public abstract class PdfjsViewer_Abstract_IntegTest extends CausewayIntegrationTestAbstract {
 
@@ -84,8 +85,7 @@ public abstract class PdfjsViewer_Abstract_IntegTest extends CausewayIntegration
                         .ignoreMixins(false)
                         .build());
         val xml = jaxbService.toXml(metamodelDto);
-
-        Approvals.verifyXml(xml, ApprovalsOptions.xmlOptions());
+        _DocumentTester.assertXmlEqualsIgnoreOrder(xml, ApprovalsOptions.xmlOptions().scrub(xml));
     }
 
     @Inject MetaModelService metaModelService;


### PR DESCRIPTION
# Test1
```org.apache.causeway.extensions.pdfjs.metamodel.PdfjsViewer_MixinDomain_IntegTest#dump_facets```
## Cause of error
This test was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was due to unmatched XML string orders. The error messages:
```
ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 7.641 s <<< FAILURE! - in org.apache.causeway.extensions.pdfjs.metamodel.PdfjsViewer_MixinDomain_IntegTest
[ERROR] org.apache.causeway.extensions.pdfjs.metamodel.PdfjsViewer_MixinDomain_IntegTest.dump_facets  Time elapsed: 1.01 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
expected: <<?xml version="1.0" encoding="UTF-8"?><mml:metamodelDto xmlns:mml="https://causeway.apache.org/schema/metamodel">
  <mml:domainClassDto id="org.apache.causeway.extensions.pdfjs.metamodel.domains.mixin.SomeViewModel">
    <mml:facets>
      <mml:facet id="org.apache.causeway.core.metamodel.facets.all.named.MemberNamedFacet" fqcn="org.apache.causeway.core.metamodel.facets.all.named.MemberNamedFacetForStaticMemberName">
        <mml:attr name="context" value="TranslationContext(name=org.apache.causeway.extensions.pdfjs.metamodel.domains.mixin.SomeViewModel#)"/>
        <mml:attr name="facet" value="MemberNamedFacetForStaticMemberName"/>
        <mml:attr name="originalText" value="Some View Model"/>
        <mml:attr name="precedence" value="DEFAULT"/>
        <mml:attr name="translated" value="Some View Model"/>
      </mml:facet>
      <mml:facet id="org.apache.causeway.core.metamodel.facets.all.named.ObjectNamedFacet" fqcn="org.apache.causeway.core.metamodel.facets.all.named.ObjectNamedFacetSynthesized">
        <mml:attr name="context" value="TranslationContext(name=org.apache.causeway.extensions.pdfjs.metamodel.domains.mixin.SomeViewModel#)"/>
        <mml:attr name="facet" value="ObjectNamedFacetSynthesized"/>
        <mml:attr name="hasNoun" value="true"/>
        <mml:attr name="originalText" value="Optional[Some View Model]"/>
        <mml:attr name="precedence" value="SYNTHESIZED"/>
        <mml:attr name="translated" value="Optional[Some View Model]"/>
      </mml:facet>
      <mml:facet id="org.apache.causeway.core.metamodel.facets.object.bookmarkpolicy.BookmarkPolicyFacet" fqcn="org.apache.causeway.core.metamodel.facets.object.bookmarkpolicy.BookmarkPolicyFacetFallback">
        <mml:attr name="bookmarkPolicy" value="NEVER"/>
        <mml:attr name="facet" value="BookmarkPolicyFacetFallback"/>
        <mml:attr name="precedence" value="FALLBACK"/>
      </mml:facet>
      <mml:facet id="org.apache.causeway.core.metamodel.facets.object.callbacks.CreatedLifecycleEventFacet" fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.CreatedLifecycleEventFacetForDomainObjectAnnotation">
        <mml:attr name="facet" value="CreatedLifecycleEventFacetForDomainObjectAnnotation"/>
        <mml:attr name="precedence" value="DEFAULT"/>
        <mml:attr name="value" value="org.apache.causeway.applib.events.lifecycle.ObjectCreatedEvent.Default"/>
      </mml:facet>
      <mml:facet id="org.apache.causeway.core.metamodel.facets.object.callbacks.LoadedLifecycleEventFacet" fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.LoadedLifecycleEventFacetForDomainObjectAnnotation">
        <mml:attr name="facet" value="LoadedLifecycleEventFacetForDomainObjectAnnotation"/>
        <mml:attr name="precedence" value="DEFAULT"/>
        <mml:attr name="value" value="org.apache.causeway.applib.events.lifecycle.ObjectLoadedEvent.Default"/>
      </mml:facet>
      <mml:facet id="org.apache.causeway.core.metamodel.facets.object.callbacks.PersistedLifecycleEventFacet" fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.PersistedLifecycleEventFacetForDomainObjectAnnotation">
        <mml:attr name="facet" value="PersistedLifecycleEventFacetForDomainObjectAnnotation"/>
        <mml:attr name="precedence" value="DEFAULT"/>
        <mml:attr name="value" value="org.apache.causeway.applib.events.lifecycle.ObjectPersistedEvent.Default"/>
      </mml:facet>
...
...
...

> but was: <<?xml version="1.0" encoding="UTF-8"?><mml:metamodelDto xmlns:mml="https://causeway.apache.org/schema/metamodel">
  <mml:domainClassDto id="org.apache.causeway.extensions.pdfjs.metamodel.domains.mixin.SomeViewModel">
    <mml:facets>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.all.named.MemberNamedFacetForStaticMemberName" id="org.apache.causeway.core.metamodel.facets.all.named.MemberNamedFacet">
        <mml:attr value="TranslationContext(name=org.apache.causeway.extensions.pdfjs.metamodel.domains.mixin.SomeViewModel#)" name="context"/>
        <mml:attr value="MemberNamedFacetForStaticMemberName" name="facet"/>
        <mml:attr value="Some View Model" name="originalText"/>
        <mml:attr value="DEFAULT" name="precedence"/>
        <mml:attr value="Some View Model" name="translated"/>
      </mml:facet>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.all.named.ObjectNamedFacetSynthesized" id="org.apache.causeway.core.metamodel.facets.all.named.ObjectNamedFacet">
        <mml:attr value="TranslationContext(name=org.apache.causeway.extensions.pdfjs.metamodel.domains.mixin.SomeViewModel#)" name="context"/>
        <mml:attr value="ObjectNamedFacetSynthesized" name="facet"/>
        <mml:attr value="true" name="hasNoun"/>
        <mml:attr value="Optional[Some View Model]" name="originalText"/>
        <mml:attr value="SYNTHESIZED" name="precedence"/>
        <mml:attr value="Optional[Some View Model]" name="translated"/>
      </mml:facet>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.object.bookmarkpolicy.BookmarkPolicyFacetFallback" id="org.apache.causeway.core.metamodel.facets.object.bookmarkpolicy.BookmarkPolicyFacet">
        <mml:attr value="NEVER" name="bookmarkPolicy"/>
        <mml:attr value="BookmarkPolicyFacetFallback" name="facet"/>
        <mml:attr value="FALLBACK" name="precedence"/>
      </mml:facet>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.CreatedLifecycleEventFacetForDomainObjectAnnotation" id="org.apache.causeway.core.metamodel.facets.object.callbacks.CreatedLifecycleEventFacet">
        <mml:attr value="CreatedLifecycleEventFacetForDomainObjectAnnotation" name="facet"/>
        <mml:attr value="DEFAULT" name="precedence"/>
        <mml:attr value="org.apache.causeway.applib.events.lifecycle.ObjectCreatedEvent.Default" name="value"/>
      </mml:facet>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.LoadedLifecycleEventFacetForDomainObjectAnnotation" id="org.apache.causeway.core.metamodel.facets.object.callbacks.LoadedLifecycleEventFacet">
        <mml:attr value="LoadedLifecycleEventFacetForDomainObjectAnnotation" name="facet"/>
        <mml:attr value="DEFAULT" name="precedence"/>
        <mml:attr value="org.apache.causeway.applib.events.lifecycle.ObjectLoadedEvent.Default" name="value"/>
      </mml:facet>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.PersistedLifecycleEventFacetForDomainObjectAnnotation" id="org.apache.causeway.core.metamodel.facets.object.callbacks.PersistedLifecycleEventFacet">
        <mml:attr value="PersistedLifecycleEventFacetForDomainObjectAnnotation" name="facet"/>
        <mml:attr value="DEFAULT" name="precedence"/>
        <mml:attr value="org.apache.causeway.applib.events.lifecycle.ObjectPersistedEvent.Default" name="value"/>
      </mml:facet>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.PersistingLifecycleEventFacetForDomainObjectAnnotation" id="org.apache.causeway.core.metamodel.facets.object.callbacks.PersistingLifecycleEventFacet">
        <mml:attr value="PersistingLifecycleEventFacetForDomainObjectAnnotation" name="facet"/>
        <mml:attr value="DEFAULT" name="precedence"/>
        <mml:attr value="org.apache.causeway.applib.events.lifecycle.ObjectPersistingEvent.Default" name="value"/>
      </mml:facet>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.RemovingLifecycleEventFacetForDomainObjectAnnotation" id="org.apache.causeway.core.metamodel.facets.object.callbacks.RemovingLifecycleEventFacet">
        <mml:attr value="RemovingLifecycleEventFacetForDomainObjectAnnotation" name="facet"/>
        <mml:attr value="DEFAULT" name="precedence"/>
        <mml:attr value="org.apache.causeway.applib.events.lifecycle.ObjectRemovingEvent.Default" name="value"/>
      </mml:facet>
      <mml:facet fqcn="org.apache.causeway.core.metamodel.facets.object.callbacks.UpdatedLifecycleEventFacetForDomainObjectAnnotation" id="org.apache.causeway.core.metamodel.facets.object.callbacks.UpdatedLifecycleEventFacet">
        <mml:attr value="UpdatedLifecycleEventFacetForDomainObjectAnnotation" name="facet"/>
        <mml:attr value="DEFAULT" name="precedence"/>
        <mml:attr value="org.apache.causeway.applib.events.lifecycle.ObjectUpdatedEvent.Default" name="value"/>
      </mml:facet>
...
```
## Changes proposed 
Since the purpose of this test is to determine the the content inside of the JSON but not the order, I used the _DocumentTester helper method to assertXmlEqualsIgnoreOrder
# Test2
```org.apache.causeway.extensions.pdfjs.metamodel.PdfjsViewer_PropDomain_IntegTest#dump_facets```
## Cause of error
Same issue above. The error messages are also similar.
## Changes proposed 
same as above.

## Changes proposed 
same as above.
# Test3
```org.apache.causeway.extensions.pdfjs.metamodel.PdfjsViewer_MixinDomainWithPdfJsViewer_IntegTest#dump_facets```
## Cause of error
Same issue above. The error messages are also similar.

## Changes proposed 
same as above.

# Test4
```org.apache.causeway.extensions.pdfjs.metamodel.PdfjsViewer_PropDomainWithPdfjsViewer_IntegTest#dump_facets```
## Cause of error
Same issue above. The error messages are also similar
## Changes proposed 
same as above.

# Debugging Environment
```
Apache Maven 3.8.4 (9b656c72d54e5bacbed989b64718c159fe39b537)
Maven home: /opt/maven/apache-maven-3.8.4
Java version: 17.0.8.1, vendor: Private Build, runtime: /usr/lib/jvm/java-17-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.4.0-167-generic", arch: "amd64", family: "unix"
```