### PR TITLE
CAUSEWAY-3663: Snapshot Pending Param Values

### DIFF
--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ParameterNegotiationModel.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ParameterNegotiationModel.java
@@ -294,6 +294,17 @@ public class ParameterNegotiationModel {
                 : null;
     }
 
+    // -- UTILITY
+
+    /**
+     * Creates a serializable {@link PendingParamsSnapshot}, that is bound to this
+     * {@link ParameterNegotiationModel}.
+     * @see PendingParamsSnapshot
+     */
+    public PendingParamsSnapshot createSnapshotModel() {
+        return PendingParamsSnapshot.create(this);
+    }
+
     // -- INTERNAL HOLDER OF PARAMETER BINDABLES
 
     private static class ParameterModel extends ManagedParameter {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/PendingParamsSnapshot.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/PendingParamsSnapshot.java
@@ -16,7 +16,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.apache.causeway.viewer.wicket.model.models.interaction.act;
+package org.apache.causeway.core.metamodel.interactions.managed;
 
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
@@ -30,9 +30,6 @@ import org.apache.causeway.commons.collections.Cardinality;
 import org.apache.causeway.commons.functional.IndexedFunction;
 import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
-import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction;
-import org.apache.causeway.core.metamodel.interactions.managed.ManagedParameter;
-import org.apache.causeway.core.metamodel.interactions.managed.ParameterNegotiationModel;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.core.metamodel.object.PackedManagedObject;
@@ -43,17 +40,20 @@ import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
 /**
- * In the event of page serialization memoizes all the current pending parameter values
+ * In the event of serialization memoizes all the current pending parameter values
  * form the {@link ParameterNegotiationModel} this instance was originally created from.
  * <p>
  * On de-serialization those snapshot-ed parameter values can be fed back into a new
  * {@link ParameterNegotiationModel} instance.
+ *
+ * @apiNote Introduced because {@link ParameterNegotiationModel} is not serializable
+ *      and we need a way to serialize pending parameter values. (see also [CAUSEWAY-3663])
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-class PendingParamsSnapshot implements Serializable {
+public class PendingParamsSnapshot implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    public static PendingParamsSnapshot create(final ParameterNegotiationModel parameterNegotiationModel) {
+    protected static PendingParamsSnapshot create(final ParameterNegotiationModel parameterNegotiationModel) {
         return new PendingParamsSnapshot(null, parameterNegotiationModel);
     }
 
@@ -78,6 +78,7 @@ class PendingParamsSnapshot implements Serializable {
         private static final long serialVersionUID = 1L;
         /**
          * For each parameter, only set if it is a plural.
+         * @implNote {@link LogicalType} is needed to recover a {@link PackedManagedObject}.
          */
         private final LogicalType[] cardinalityConstraints;
         private final Can<Can<Bookmark>> argBookmarks;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/PropertyNegotiationModel.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/PropertyNegotiationModel.java
@@ -28,7 +28,7 @@ import org.apache.causeway.commons.internal.binding._Bindables;
 import org.apache.causeway.commons.internal.binding._Observables;
 import org.apache.causeway.commons.internal.binding._Observables.BooleanObservable;
 import org.apache.causeway.commons.internal.binding._Observables.LazyObservable;
-import org.apache.causeway.commons.internal.debug._Debug;
+import org.apache.causeway.commons.internal.debug._XrayEvent;
 import org.apache.causeway.commons.internal.debug.xray.XrayUi;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.interactions.managed._BindingUtil.TargetFormat;
@@ -216,12 +216,11 @@ public class PropertyNegotiationModel implements ManagedValue {
     // -- SUBMISSION
 
     public void submit() {
-
-        _Debug.onCondition(XrayUi.isXrayEnabled(), ()->{
-            _Debug.log("[PENDING MODEL] submit pending property value '%s' into owning object", getValue().getValue());
-        });
-
-        managedProperty.modifyProperty(getValue().getValue());
+        var newPropertyValue = getValue().getValue();
+        if(XrayUi.isXrayEnabled()) {
+            _XrayEvent.event("[PENDING MODEL] submit pending property value '%s' into owning object", newPropertyValue);
+        }
+        managedProperty.modifyProperty(newPropertyValue);
         isCurrentValueAbsent.invalidate();
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/objectmanager/ObjectManager.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/objectmanager/ObjectManager.java
@@ -30,6 +30,8 @@ import org.apache.causeway.commons.internal.base._NullSafe;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.core.metamodel.context.HasMetaModelContext;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
+import org.apache.causeway.core.metamodel.object.ManagedObjects;
+import org.apache.causeway.core.metamodel.object.PackedManagedObject;
 import org.apache.causeway.core.metamodel.object.ProtoObject;
 import org.apache.causeway.core.metamodel.objectmanager.memento.ObjectMemento;
 import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
@@ -108,6 +110,28 @@ public interface ObjectManager extends HasMetaModelContext {
         val specLoader = getMetaModelContext().getSpecificationLoader();
         return ProtoObject.resolve(specLoader, bookmark)
                 .map(this::loadObject);
+    }
+
+    /**
+     * Introduced for serializing action parameter values to bookmarks and vice versa.
+     * <p>
+     * Does NOT handle {@link PackedManagedObject}. (Needs to be handled by the caller.)
+     * @see #debookmark(Bookmark)
+     */
+    default Bookmark bookmark(final @NonNull ManagedObject managedObj) {
+        return ManagedObjects.bookmark(managedObj)
+                .orElseGet(()->Bookmark.empty(managedObj.getLogicalType()));
+    }
+    /**
+     * Introduced for de-serializing action parameter values from bookmarks and vice versa.
+     * <p>
+     * Does NOT handle {@link PackedManagedObject}. (Needs to be handled by the caller.)
+     * @see #bookmark(ManagedObject)
+     */
+    default ManagedObject debookmark(final @NonNull Bookmark bookmark) {
+        return bookmark.isEmpty()
+            ? ManagedObject.empty(getSpecificationLoader().specForBookmarkElseFail(bookmark))
+            : loadObjectElseFail(bookmark);
     }
 
     /**

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/act/ActionInteractionWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/act/ActionInteractionWkt.java
@@ -33,6 +33,7 @@ import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.core.metamodel.interactions.managed.ActionInteraction;
 import org.apache.causeway.core.metamodel.interactions.managed.ParameterNegotiationModel;
+import org.apache.causeway.core.metamodel.interactions.managed.PendingParamsSnapshot;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.core.metamodel.spec.feature.ObjectAction;
 import org.apache.causeway.core.metamodel.spec.feature.memento.ActionMemento;
@@ -259,7 +260,7 @@ extends HasBookmarkedOwnerAbstract<ActionInteraction> {
     private ParameterNegotiationModel startParameterNegotiationModel() {
         this.parameterNegotiationModel = actionInteraction().startParameterNegotiation()
                 .orElseThrow(()->_Exceptions.noSuchElement(memberId));
-        this.pendingParamsSnapshot = PendingParamsSnapshot.create(parameterNegotiationModel);
+        this.pendingParamsSnapshot = parameterNegotiationModel.createSnapshotModel();
         return parameterNegotiationModel;
     }
     /**

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/act/PendingParamsSnapshot.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/act/PendingParamsSnapshot.java
@@ -1,0 +1,95 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.viewer.wicket.model.models.interaction.act;
+
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+
+import org.apache.causeway.applib.services.bookmark.Bookmark;
+import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.core.metamodel.context.MetaModelContext;
+import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction;
+import org.apache.causeway.core.metamodel.interactions.managed.ParameterNegotiationModel;
+import org.apache.causeway.core.metamodel.object.ManagedObject;
+import org.apache.causeway.core.metamodel.object.ManagedObjects;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+/**
+ * In the event of page serialization memoizes all the current pending parameter values
+ * form the {@link ParameterNegotiationModel} this instance was originally created from.
+ * <p>
+ * On de-serialization those snapshot-ed parameter values can be fed back into a new
+ * {@link ParameterNegotiationModel} instance.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+class PendingParamsSnapshot implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public static PendingParamsSnapshot create(final ParameterNegotiationModel parameterNegotiationModel) {
+        return new PendingParamsSnapshot(null, parameterNegotiationModel);
+    }
+
+    private Can<ManagedObject> parameterValues;
+    private ParameterNegotiationModel parameterNegotiationModel;
+
+    public ParameterNegotiationModel restoreParameterNegotiationModel(final ManagedAction managedAction) {
+        return this.parameterNegotiationModel = ParameterNegotiationModel.of(managedAction, parameterValues);
+    }
+
+    // -- SERIALIZATION PROXY
+
+    private Object writeReplace() {
+        return new SerializationProxy(this);
+    }
+
+    private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
+        throw new InvalidObjectException("Proxy required");
+    }
+
+    private static class SerializationProxy implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final Can<Bookmark> argBookmarks;
+
+        //TODO[CAUSEWAY-3663] also handle PackedManagedObject
+        private SerializationProxy(final PendingParamsSnapshot pvm) {
+            this.argBookmarks = pvm.parameterNegotiationModel.getParamValues()
+                    .map(managedObj->ManagedObjects.bookmark(managedObj)
+                            .orElseGet(()->Bookmark.empty(managedObj.getLogicalType())));
+        }
+
+        //TODO[CAUSEWAY-3663] also handle PackedManagedObject
+        private Object readResolve() {
+            var objectManager = MetaModelContext.instanceElseFail().getObjectManager();
+            return new PendingParamsSnapshot(
+                    argBookmarks.map(bookmark->
+                        bookmark.isEmpty()
+                        ? ManagedObject.empty(
+                                objectManager.getSpecificationLoader().specForBookmarkElseFail(bookmark))
+                        : objectManager
+                            .loadObject(bookmark)
+                            .orElseThrow()),
+                    null);
+        }
+
+    }
+
+}


### PR DESCRIPTION
- [x] In the event of page serialization, we need to memoize all the current pending parameter values of the non-serializable  `ParameterNegotiationModel`, so we can recover an open action dialog, that belongs to a page that suffered a serialization by Wicket during parameter negotiation (eg. because the app was loaded in a different browser tab).
- [x] Perhaps refactor the new serialization helper `PendingParamsSnapshot` to be closer to the `ParameterNegotiationModel`.