### PR TITLE
CAUSEWAY-3689: adds config param to disallow grouping (thousands) sep…

### DIFF
--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
@@ -224,14 +224,14 @@ ValueSemanticsProvider<T> {
             return Optional.empty();
         }
         try {
-            return parseDecimal(context, input, GroupingSeparatorWhenParsePolicy.ALLOW)
+            return parseDecimal(context, input, GroupingSeparatorPolicy.ALLOW)
                     .map(BigDecimal::toBigIntegerExact);
         } catch (final NumberFormatException | ArithmeticException e) {
             throw new TextEntryParseException("Not an integer value " + text, e);
         }
     }
 
-    protected enum GroupingSeparatorWhenParsePolicy {
+    protected enum GroupingSeparatorPolicy {
         ALLOW,
         DISALLOW,
         ;
@@ -240,13 +240,13 @@ ValueSemanticsProvider<T> {
     protected Optional<BigDecimal> parseDecimal(
             final @Nullable Context context,
             final @Nullable String text,
-            final GroupingSeparatorWhenParsePolicy parsePolicy) {
+            final GroupingSeparatorPolicy groupingSeparatorPolicy) {
         val input = _Strings.blankToNullOrTrim(text);
         if(input==null) {
             return Optional.empty();
         }
 
-        if (parsePolicy == GroupingSeparatorWhenParsePolicy.DISALLOW) {
+        if (groupingSeparatorPolicy == GroupingSeparatorPolicy.DISALLOW) {
             val userLocale = getUserLocale(context);
             val decimalFormatSymbols = new DecimalFormatSymbols(userLocale.getNumberFormatLocale());
             val groupingSeparatorChar = decimalFormatSymbols.getGroupingSeparator();

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/ValueSemanticsAbstract.java
@@ -247,14 +247,13 @@ ValueSemanticsProvider<T> {
         }
 
         if (parsePolicy == GroupingSeparatorWhenParsePolicy.DISALLOW) {
-            UserLocale userLocale = getUserLocale(context);
+            val userLocale = getUserLocale(context);
             val decimalFormatSymbols = new DecimalFormatSymbols(userLocale.getNumberFormatLocale());
-            char groupingSeparator = decimalFormatSymbols.getGroupingSeparator();
-            if (input.contains(""+groupingSeparator)) {
-                throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + groupingSeparator + "' grouping separator");
+            val groupingSeparatorChar = decimalFormatSymbols.getGroupingSeparator();
+            if (input.contains(""+groupingSeparatorChar)) {
+                throw new TextEntryParseException("Invalid value '" + input + "'; do not use the '" + groupingSeparatorChar + "' grouping separator");
             }
         }
-
 
         val format = getNumberFormat(context, FormatUsageFor.PARSING);
         format.setParseBigDecimal(true);

--- a/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
+++ b/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
@@ -3263,6 +3263,29 @@ public class CausewayConfiguration {
              * either {@link Digits#fraction()} or an ORM semantic such as the (JPA) {@link Column#scale()}.
              */
             private Integer minScale = null;
+
+            /**
+             * A common use of {@link java.math.BigDecimal} is as a money value.  In some locales (eg English), the
+             * &quot;,&quot; (comma) is the grouping (thousands) separator wihle the &quot;.&quot; (period) acts as a
+             * decimal point, but in others (eg France, Italy) it is the other way around.
+             *
+             * <p>
+             *     Surprisingly perhaps, a string such as "123,99", when parsed ((by {@link java.text.DecimalFormat})
+             *     in an English locale, is not rejected but instead is evaluated as the value 12399L.  That's almost
+             *     certainly not what the end-user would have expected, and results in a money value 100x too large.
+             * </p>
+             *
+             * <p>
+             *     The purpose of this configuration property is to remove the confusion by simply disallowing the
+             *     thousands separator from being part of the input string.
+             * </p>
+             *
+             * <p>
+             *     For maximum safety, allowing the grouping separator is disallowed, but the alternate (original)
+             *     behaviour can be reinstated by setting this config property back to <code>true</code>.
+             * </p>
+             */
+            private boolean allowGroupingSeparatorWhenParse = false;
         }
 
         private final Kroki kroki = new Kroki();

--- a/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
+++ b/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
@@ -3284,8 +3284,12 @@ public class CausewayConfiguration {
              *     For maximum safety, allowing the grouping separator is disallowed, but the alternate (original)
              *     behaviour can be reinstated by setting this config property back to <code>true</code>.
              * </p>
+             *
+             * <p>
+             *     The same configuration property is also used for rendering the value.
+             * </p>
              */
-            private boolean allowGroupingSeparatorWhenParse = false;
+            private boolean useGroupingSeparator = false;
         }
 
         private final Kroki kroki = new Kroki();

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/_testing/MetaModelContext_forTesting.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/_testing/MetaModelContext_forTesting.java
@@ -593,6 +593,7 @@ extends MetaModelContext {
             ValueFacetForValueAnnotationOrAnyMatchingValueSemanticsFacetFactory
             .installValueFacet(valueClass, Can.of(valueSemantics), primitiveTypeSpec);
         }
+        serviceInjector.injectServicesInto(valueSemantics);
         return this;
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -131,8 +131,8 @@ implements
     @Override
     public BigDecimal parseTextRepresentation(final ValueSemanticsProvider.Context context, final String text) {
         val parsePolicy = causewayConfiguration.getValueTypes().getBigDecimal().isUseGroupingSeparator()
-                                ? GroupingSeparatorWhenParsePolicy.ALLOW
-                                : GroupingSeparatorWhenParsePolicy.DISALLOW;
+                                ? GroupingSeparatorPolicy.ALLOW
+                                : GroupingSeparatorPolicy.DISALLOW;
         return super.parseDecimal(context, text, parsePolicy)
                 .orElse(null);
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -130,7 +130,7 @@ implements
 
     @Override
     public BigDecimal parseTextRepresentation(final ValueSemanticsProvider.Context context, final String text) {
-        val parsePolicy = causewayConfiguration.getValueTypes().getBigDecimal().isAllowGroupingSeparatorWhenParse()
+        val parsePolicy = causewayConfiguration.getValueTypes().getBigDecimal().isUseGroupingSeparator()
                                 ? GroupingSeparatorWhenParsePolicy.ALLOW
                                 : GroupingSeparatorWhenParsePolicy.DISALLOW;
         return super.parseDecimal(context, text, parsePolicy)
@@ -145,6 +145,9 @@ implements
     @Override
     protected void configureDecimalFormat(
             final Context context, final DecimalFormat format, final FormatUsageFor usedFor) {
+
+        format.setGroupingUsed(causewayConfiguration.getValueTypes().getBigDecimal().isUseGroupingSeparator());
+
         if(context==null) {
             return;
         }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/BigDecimalValueSemantics.java
@@ -130,7 +130,10 @@ implements
 
     @Override
     public BigDecimal parseTextRepresentation(final ValueSemanticsProvider.Context context, final String text) {
-        return super.parseDecimal(context, text)
+        val parsePolicy = causewayConfiguration.getValueTypes().getBigDecimal().isAllowGroupingSeparatorWhenParse()
+                                ? GroupingSeparatorWhenParsePolicy.ALLOW
+                                : GroupingSeparatorWhenParsePolicy.DISALLOW;
+        return super.parseDecimal(context, text, parsePolicy)
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -101,7 +101,7 @@ implements
 
     @Override
     public Double parseTextRepresentation(final Context context, final String text) {
-        return _Doubles.convertToDouble(super.parseDecimal(context, text))
+        return _Doubles.convertToDouble(super.parseDecimal(context, text, GroupingSeparatorWhenParsePolicy.ALLOW))
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/DoubleValueSemantics.java
@@ -101,7 +101,7 @@ implements
 
     @Override
     public Double parseTextRepresentation(final Context context, final String text) {
-        return _Doubles.convertToDouble(super.parseDecimal(context, text, GroupingSeparatorWhenParsePolicy.ALLOW))
+        return _Doubles.convertToDouble(super.parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -101,7 +101,7 @@ implements
 
     @Override
     public Float parseTextRepresentation(final Context context, final String text) {
-        return _Floats.convertToFloat(super.parseDecimal(context, text, GroupingSeparatorWhenParsePolicy.ALLOW))
+        return _Floats.convertToFloat(super.parseDecimal(context, text, GroupingSeparatorPolicy.ALLOW))
                 .orElse(null);
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/valuesemantics/FloatValueSemantics.java
@@ -101,7 +101,7 @@ implements
 
     @Override
     public Float parseTextRepresentation(final Context context, final String text) {
-        return _Floats.convertToFloat(super.parseDecimal(context, text))
+        return _Floats.convertToFloat(super.parseDecimal(context, text, GroupingSeparatorWhenParsePolicy.ALLOW))
                 .orElse(null);
     }
 

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigDecimalValueSemanticsProviderTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/facets/value/BigDecimalValueSemanticsProviderTest.java
@@ -37,6 +37,7 @@ import org.apache.causeway.core.metamodel.valuesemantics.BigDecimalValueSemantic
 class BigDecimalValueSemanticsProviderTest
 extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
 
+    private final CausewayConfiguration causewayConfiguration = new CausewayConfiguration(null, null);
     private BigDecimalValueSemantics value;
     private BigDecimal bigDecimal;
 
@@ -46,7 +47,7 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
         allowMockAdapterToReturn(bigDecimal);
 
         BigDecimalValueSemantics valueSemantics = new BigDecimalValueSemantics();
-        valueSemantics.setCausewayConfiguration(new CausewayConfiguration(null, null));
+        valueSemantics.setCausewayConfiguration(causewayConfiguration);
         setSemantics(value = valueSemantics);
     }
 
@@ -76,9 +77,7 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
 
     @Test
     void parseValidStringWithGroupingSeparatorIfConfiguredToAllow() throws Exception {
-        val causewayConfiguration = new CausewayConfiguration(null, null);
-        causewayConfiguration.getValueTypes().getBigDecimal().setAllowGroupingSeparatorWhenParse(true);
-        value.setCausewayConfiguration(causewayConfiguration);
+        causewayConfiguration.getValueTypes().getBigDecimal().setUseGroupingSeparator(true);
 
         value.parseTextRepresentation(null, "123,999.01");
     }
@@ -94,9 +93,7 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
         }
 
         // but if we allow it...
-        val causewayConfiguration = new CausewayConfiguration(null, null);
-        causewayConfiguration.getValueTypes().getBigDecimal().setAllowGroupingSeparatorWhenParse(true);
-        value.setCausewayConfiguration(causewayConfiguration);
+        causewayConfiguration.getValueTypes().getBigDecimal().setUseGroupingSeparator(true);
 
         BigDecimal bigDecimal = value.parseTextRepresentation(null, "1239,99");
         Assertions.assertThat(bigDecimal).isEqualTo(new BigDecimal(123999));
@@ -109,6 +106,13 @@ extends ValueSemanticsProviderAbstractTestCase<BigDecimal> {
 
     @Test
     void titleOf() {
+        assertEquals("34132.199", value.titlePresentation(null, bigDecimal));
+    }
+
+    @Test
+    void titleOfWhenUseGroupingSeparator() {
+        causewayConfiguration.getValueTypes().getBigDecimal().setUseGroupingSeparator(true);
+
         assertEquals("34,132.199", value.titlePresentation(null, bigDecimal));
     }
 

--- a/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/ConverterTester.java
+++ b/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/ConverterTester.java
@@ -23,6 +23,8 @@ import java.math.BigDecimal;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.apache.causeway.core.config.CausewayConfiguration;
+
 import org.apache.wicket.util.convert.ConversionException;
 import org.assertj.core.util.Arrays;
 import org.mockito.Mockito;
@@ -132,6 +134,10 @@ public class ConverterTester<T extends Serializable> {
             final @NonNull T value,
             final @NonNull String valueAsText) {
         assertRoundtrip(value, valueAsText, valueAsText);
+    }
+
+    public CausewayConfiguration.ValueTypes.BigDecimal getConfigurationForBigDecimalValueType() {
+        return mmc.getConfiguration().getValueTypes().getBigDecimal();
     }
 
     /**

--- a/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/jdkmath/BigDecimalConverterTest.java
+++ b/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/jdkmath/BigDecimalConverterTest.java
@@ -36,6 +36,8 @@ import org.apache.causeway.viewer.wicket.ui.test.components.scalars.ConverterTes
 import lombok.Getter;
 import lombok.Setter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class BigDecimalConverterTest {
 
     final BigDecimal bd_123_45_scale2 = new BigDecimal("123.45").setScale(2);
@@ -81,7 +83,18 @@ class BigDecimalConverterTest {
     }
 
     @Test
-    void scale2_english_withThousandSeparators() {
+    void scale2_english_withThousandSeparators_not_allowed() {
+        assertThat(converterTester.getConfigurationForBigDecimalValueType().isAllowGroupingSeparatorWhenParse()).isFalse();
+
+        converterTester.setScenario(Locale.ENGLISH, newConverter(CustomerScale2.class));
+        converterTester.assertConversionFailure("789,123.45", "Invalid value '789,123.45'; do not use the ',' grouping separator");
+    }
+
+    @Test
+    void scale2_english_withThousandSeparators_allowed() {
+        converterTester.getConfigurationForBigDecimalValueType().setAllowGroupingSeparatorWhenParse(true);
+        assertThat(converterTester.getConfigurationForBigDecimalValueType().isAllowGroupingSeparatorWhenParse()).isTrue();
+
         converterTester.setScenario(Locale.ENGLISH, newConverter(CustomerScale2.class));
         converterTester.assertRoundtrip(bd_789123_45_scale2, "789,123.45");
     }

--- a/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/jdkmath/BigDecimalConverterTest.java
+++ b/viewers/wicket/ui-test/src/test/java/org/apache/causeway/viewer/wicket/ui/test/components/scalars/jdkmath/BigDecimalConverterTest.java
@@ -84,7 +84,7 @@ class BigDecimalConverterTest {
 
     @Test
     void scale2_english_withThousandSeparators_not_allowed() {
-        assertThat(converterTester.getConfigurationForBigDecimalValueType().isAllowGroupingSeparatorWhenParse()).isFalse();
+        assertThat(converterTester.getConfigurationForBigDecimalValueType().isUseGroupingSeparator()).isFalse();
 
         converterTester.setScenario(Locale.ENGLISH, newConverter(CustomerScale2.class));
         converterTester.assertConversionFailure("789,123.45", "Invalid value '789,123.45'; do not use the ',' grouping separator");
@@ -92,8 +92,8 @@ class BigDecimalConverterTest {
 
     @Test
     void scale2_english_withThousandSeparators_allowed() {
-        converterTester.getConfigurationForBigDecimalValueType().setAllowGroupingSeparatorWhenParse(true);
-        assertThat(converterTester.getConfigurationForBigDecimalValueType().isAllowGroupingSeparatorWhenParse()).isTrue();
+        converterTester.getConfigurationForBigDecimalValueType().setUseGroupingSeparator(true);
+        assertThat(converterTester.getConfigurationForBigDecimalValueType().isUseGroupingSeparator()).isTrue();
 
         converterTester.setScenario(Locale.ENGLISH, newConverter(CustomerScale2.class));
         converterTester.assertRoundtrip(bd_789123_45_scale2, "789,123.45");
@@ -102,7 +102,7 @@ class BigDecimalConverterTest {
     @Test
     void scale2_english_withoutThousandSeparators() {
         converterTester.setScenario(Locale.ENGLISH, newConverter(CustomerScale2.class));
-        converterTester.assertRoundtrip(bd_789123_45_scale2, "789123.45", "789,123.45");
+        converterTester.assertRoundtrip(bd_789123_45_scale2, "789123.45");
     }
 
     @Test


### PR DESCRIPTION
…arator

when parsing BigDecimals ... because these are often used as money, risk of misinterpretation