### PR TITLE
CAUSEWAY-3489: Temporal Editing with Zone or Offset (Wicket Vwr)

### DIFF
--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/TemporalValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/TemporalValueSemantics.java
@@ -19,13 +19,18 @@
 package org.apache.causeway.applib.value.semantics;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.causeway.applib.annotation.TimePrecision;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 
 import lombok.Data;
 import lombok.NonNull;
+import lombok.val;
 
 /**
  * Common base for {@link java.time.temporal.Temporal} value types.
@@ -347,6 +352,29 @@ extends
             throw _Exceptions.unmatchedCase(timePrecision);
         }
 
+    }
+
+    /**
+     * For temporal value editing, provides the list of available time zones to choose from.
+     */
+    default List<ZoneId> getAvailableZoneIds() {
+        return ZoneId.getAvailableZoneIds().stream()
+                .sorted()
+                .map(ZoneId::of)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * For temporal value editing, provides the list of available offsets to choose from.
+     */
+    default List<ZoneId> getAvailableOffsets() {
+        val now = LocalDateTime.now();
+        return ZoneId.getAvailableZoneIds().stream()
+                .map(ZoneId::of)
+                .map(ZoneId::getRules)
+                .flatMap(zoneIdRules->zoneIdRules.getValidOffsets(now).stream())
+                .sorted()
+                .collect(Collectors.toList());
     }
 
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/TemporalValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/TemporalValueSemantics.java
@@ -21,6 +21,7 @@ package org.apache.causeway.applib.value.semantics;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -367,7 +368,7 @@ extends
     /**
      * For temporal value editing, provides the list of available offsets to choose from.
      */
-    default List<ZoneId> getAvailableOffsets() {
+    default List<ZoneOffset> getAvailableOffsets() {
         val now = LocalDateTime.now();
         return ZoneId.getAvailableZoneIds().stream()
                 .map(ZoneId::of)

--- a/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/TemporalValueSemantics.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/value/semantics/TemporalValueSemantics.java
@@ -360,9 +360,9 @@ extends
      */
     default List<ZoneId> getAvailableZoneIds() {
         return ZoneId.getAvailableZoneIds().stream()
-                .sorted()
-                .map(ZoneId::of)
-                .collect(Collectors.toList());
+            .sorted()
+            .map(ZoneId::of)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -370,12 +370,12 @@ extends
      */
     default List<ZoneOffset> getAvailableOffsets() {
         val now = LocalDateTime.now();
-        return ZoneId.getAvailableZoneIds().stream()
-                .map(ZoneId::of)
-                .map(ZoneId::getRules)
-                .flatMap(zoneIdRules->zoneIdRules.getValidOffsets(now).stream())
-                .sorted()
-                .collect(Collectors.toList());
+        return getAvailableZoneIds().stream()
+            .map(ZoneId::getRules)
+            .flatMap(zoneIdRules->zoneIdRules.getValidOffsets(now).stream())
+            .sorted()
+            .distinct()
+            .collect(Collectors.toList());
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/util/Facets.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/util/Facets.java
@@ -34,6 +34,7 @@ import org.apache.causeway.applib.annotation.TableDecorator;
 import org.apache.causeway.applib.annotation.Where;
 import org.apache.causeway.applib.id.LogicalType;
 import org.apache.causeway.applib.layout.grid.bootstrap.BSGrid;
+import org.apache.causeway.applib.value.semantics.TemporalValueSemantics;
 import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Casts;
@@ -95,8 +96,8 @@ public final class Facets {
     public Can<ManagedObject> autoCompleteExecute(
             final ObjectSpecification objectSpec, final String term) {
         return objectSpec.lookupFacet(AutoCompleteFacet.class)
-        .map(autoCompleteFacet->autoCompleteFacet.execute(term, InteractionInitiatedBy.USER))
-        .orElseGet(Can::empty);
+            .map(autoCompleteFacet->autoCompleteFacet.execute(term, InteractionInitiatedBy.USER))
+            .orElseGet(Can::empty);
     }
 
     public boolean autoCompleteIsPresent(final ObjectSpecification objectSpec) {
@@ -105,15 +106,15 @@ public final class Facets {
 
     public OptionalInt autoCompleteMinLength(final ObjectSpecification objectSpec) {
         return objectSpec.lookupFacet(AutoCompleteFacet.class)
-        .map(AutoCompleteFacet::getMinLength)
-        .map(OptionalInt::of)
-        .orElseGet(OptionalInt::empty);
+            .map(AutoCompleteFacet::getMinLength)
+            .map(OptionalInt::of)
+            .orElseGet(OptionalInt::empty);
     }
 
     public Optional<BookmarkPolicy> bookmarkPolicy(final @Nullable FacetHolder facetHolder) {
         return Optional.ofNullable(facetHolder)
-        .flatMap(spec->spec.lookupFacet(BookmarkPolicyFacet.class))
-        .map(BookmarkPolicyFacet::value);
+            .flatMap(spec->spec.lookupFacet(BookmarkPolicyFacet.class))
+            .map(BookmarkPolicyFacet::value);
     }
 
     public BookmarkPolicy bookmarkPolicyOrElseNotSpecified(final @Nullable FacetHolder facetHolder) {
@@ -123,8 +124,8 @@ public final class Facets {
     public Optional<BSGrid> bootstrapGrid(
             final ObjectSpecification objectSpec, final @Nullable ManagedObject objectAdapter) {
         return objectSpec.lookupFacet(GridFacet.class)
-        .map(gridFacet->gridFacet.getGrid(objectAdapter))
-        .flatMap(grid->_Casts.castTo(BSGrid.class, grid));
+            .map(gridFacet->gridFacet.getGrid(objectAdapter))
+            .flatMap(grid->_Casts.castTo(BSGrid.class, grid));
     }
 
     public Optional<BSGrid> bootstrapGrid(final ObjectSpecification objectSpec) {
@@ -144,20 +145,20 @@ public final class Facets {
     public Stream<ManagedObject> collectionStream(
             final ObjectSpecification objectSpec, final @Nullable ManagedObject collection) {
         return objectSpec.lookupFacet(CollectionFacet.class)
-        .map(collectionFacet->collectionFacet.stream(collection))
-        .orElseGet(Stream::empty);
+            .map(collectionFacet->collectionFacet.stream(collection))
+            .orElseGet(Stream::empty);
     }
 
     public Optional<String> cssClass(
             final FacetHolder facetHolder, final ManagedObject objectAdapter) {
         return facetHolder.lookupFacet(CssClassFacet.class)
-        .map(cssClassFacet->cssClassFacet.cssClass(objectAdapter));
+            .map(cssClassFacet->cssClassFacet.cssClass(objectAdapter));
     }
 
     public int dateRenderAdjustDays(final ObjectFeature feature) {
         return feature.lookupFacet(DateRenderAdjustFacet.class)
-        .map(DateRenderAdjustFacet::getDateRenderAdjustDays)
-        .orElse(0);
+            .map(DateRenderAdjustFacet::getDateRenderAdjustDays)
+            .orElse(0);
     }
 
     public boolean defaultViewIsPresent(final ObjectFeature feature) {
@@ -166,20 +167,20 @@ public final class Facets {
 
     public boolean defaultViewIsTable(final ObjectFeature feature) {
         return defaultViewName(feature)
-        .map(viewName->"table".equals(viewName))
-        .orElse(false);
+            .map(viewName->"table".equals(viewName))
+            .orElse(false);
     }
 
     public Optional<String> defaultViewName(final ObjectFeature feature) {
         return feature.lookupFacet(DefaultViewFacet.class)
-        .map(DefaultViewFacet::value);
+            .map(DefaultViewFacet::value);
     }
 
     public static ParameterConfigOptions.PrecedingParametersPolicy precedingParametersPolicy(
             final ObjectActionParameter parameter) {
         return parameter.lookupFacet(PrecedingParametersPolicyFacet.class)
-                .map(PrecedingParametersPolicyFacet::value)
-                .orElseGet(ParameterConfigOptions.PrecedingParametersPolicy::defaultsIfNotSpecifiedOtherwise);
+            .map(PrecedingParametersPolicyFacet::value)
+            .orElseGet(ParameterConfigOptions.PrecedingParametersPolicy::defaultsIfNotSpecifiedOtherwise);
     }
 
     public boolean domainServiceIsPresent(final ObjectSpecification objectSpec) {
@@ -188,33 +189,33 @@ public final class Facets {
 
     public Optional<MenuBar> domainServiceLayoutMenuBar(final ObjectSpecification objectSpec) {
         return objectSpec.lookupFacet(DomainServiceLayoutFacet.class)
-        .map(DomainServiceLayoutFacet::getMenuBar);
+            .map(DomainServiceLayoutFacet::getMenuBar);
     }
 
     public Optional<String> fileAccept(final ObjectFeature feature) {
         return feature.lookupFacet(FileAcceptFacet.class)
-        .map(FileAcceptFacet::value);
+            .map(FileAcceptFacet::value);
     }
 
     public void gridPreload(
             final ObjectSpecification objectSpec, final ManagedObject objectAdapter) {
         objectSpec.lookupFacet(GridFacet.class)
-        .ifPresent(gridFacet->
-            // the facet should always exist, in fact
-            // just enough to ask for the metadata.
-            // This will cause the current ObjectSpec to be updated as a side effect.
-            gridFacet.getGrid(objectAdapter));
+            .ifPresent(gridFacet->
+                // the facet should always exist, in fact
+                // just enough to ask for the metadata.
+                // This will cause the current ObjectSpec to be updated as a side effect.
+                gridFacet.getGrid(objectAdapter));
     }
 
     public Optional<Where> hiddenWhere(final ObjectFeature feature) {
         return feature.lookupFacet(HiddenFacet.class)
-        .map(HiddenFacet::where);
+            .map(HiddenFacet::where);
     }
 
     public Predicate<ObjectFeature> hiddenWhereMatches(final Predicate<Where> matcher) {
         return feature->Facets.hiddenWhere(feature)
-        .map(matcher::test)
-        .orElse(false);
+            .map(matcher::test)
+            .orElse(false);
     }
 
     public boolean iconIsPresent(final ObjectSpecification objectSpec) {
@@ -226,21 +227,21 @@ public final class Facets {
      */
     public LabelPosition labelAt(final ObjectFeature feature) {
         return feature.lookupFacet(LabelAtFacet.class)
-                .map(LabelAtFacet::label)
-                .map(labelPos->{
-                    switch (labelPos) {
-                    case LEFT:
-                    case RIGHT:
-                    case NONE:
-                    case TOP:
-                        return labelPos;
-                    case DEFAULT:
-                    case NOT_SPECIFIED:
-                    default:
-                        return LabelPosition.LEFT;
-                    }
-                })
-                .orElse(LabelPosition.LEFT);
+            .map(LabelAtFacet::label)
+            .map(labelPos->{
+                switch (labelPos) {
+                case LEFT:
+                case RIGHT:
+                case NONE:
+                case TOP:
+                    return labelPos;
+                case DEFAULT:
+                case NOT_SPECIFIED:
+                default:
+                    return LabelPosition.LEFT;
+                }
+            })
+            .orElse(LabelPosition.LEFT);
     }
 
     public String labelAtCss(final ObjectFeature feature) {
@@ -249,47 +250,47 @@ public final class Facets {
 
     public OptionalInt minFractionalDigits(final FacetHolder facetHolder) {
         return facetHolder.lookupFacet(MinFractionalDigitsFacet.class)
-        .map(MinFractionalDigitsFacet::getMinFractionalDigits)
-        .filter(digits->digits>-1)
-        .map(OptionalInt::of)
-        .orElseGet(OptionalInt::empty);
+            .map(MinFractionalDigitsFacet::getMinFractionalDigits)
+            .filter(digits->digits>-1)
+            .map(OptionalInt::of)
+            .orElseGet(OptionalInt::empty);
     }
 
     public OptionalInt maxFractionalDigits(final FacetHolder facetHolder) {
         return facetHolder.lookupFacet(MaxFractionalDigitsFacet.class)
-        .map(MaxFractionalDigitsFacet::getMaxFractionalDigits)
-        .filter(digits->digits>-1)
-        .map(OptionalInt::of)
-        .orElseGet(OptionalInt::empty);
+            .map(MaxFractionalDigitsFacet::getMaxFractionalDigits)
+            .filter(digits->digits>-1)
+            .map(OptionalInt::of)
+            .orElseGet(OptionalInt::empty);
     }
 
     public OptionalInt maxFractionalDigits(final @Nullable Iterable<FacetHolder> facetHolders) {
         return _NullSafe.stream(facetHolders)
-                .map(Facets::maxFractionalDigits)
-                .findFirst()
-                .orElseGet(OptionalInt::empty);
+            .map(Facets::maxFractionalDigits)
+            .findFirst()
+            .orElseGet(OptionalInt::empty);
     }
 
     public OptionalInt maxLength(final FacetHolder facetHolder) {
         return facetHolder
-                .lookupFacet(MaxLengthFacet.class)
-                .map(MaxLengthFacet::value)
-                .map(OptionalInt::of)
-                .orElseGet(OptionalInt::empty);
+            .lookupFacet(MaxLengthFacet.class)
+            .map(MaxLengthFacet::value)
+            .map(OptionalInt::of)
+            .orElseGet(OptionalInt::empty);
     }
 
     public OptionalInt maxTotalDigits(final FacetHolder facetHolder) {
         return facetHolder.lookupFacet(MaxTotalDigitsFacet.class)
-        .map(MaxTotalDigitsFacet::getMaxTotalDigits)
-        .map(OptionalInt::of)
-        .orElseGet(OptionalInt::empty);
+            .map(MaxTotalDigitsFacet::getMaxTotalDigits)
+            .map(OptionalInt::of)
+            .orElseGet(OptionalInt::empty);
     }
 
     public OptionalInt maxTotalDigits(final @Nullable Iterable<FacetHolder> facetHolders) {
         return _NullSafe.stream(facetHolders)
-                .map(Facets::maxTotalDigits)
-                .findFirst()
-                .orElseGet(OptionalInt::empty);
+            .map(Facets::maxTotalDigits)
+            .findFirst()
+            .orElseGet(OptionalInt::empty);
     }
 
     public boolean mixinIsPresent(final ObjectSpecification objectSpec) {
@@ -298,46 +299,46 @@ public final class Facets {
 
     public boolean multilineIsPresent(final ObjectFeature feature) {
         return feature.lookupNonFallbackFacet(MultiLineFacet.class)
-                .isPresent();
+            .isPresent();
     }
 
     public OptionalInt multilineNumberOfLines(final ObjectFeature feature) {
         return feature
-                .lookupFacet(MultiLineFacet.class)
-                .map(MultiLineFacet::numberOfLines)
-                .map(OptionalInt::of)
-                .orElseGet(OptionalInt::empty);
+            .lookupFacet(MultiLineFacet.class)
+            .map(MultiLineFacet::numberOfLines)
+            .map(OptionalInt::of)
+            .orElseGet(OptionalInt::empty);
     }
 
     //XXX could be moved to ManagedObject directly
     public ManagedObject projected(final ManagedObject objectAdapter) {
         return objectAdapter.getSpecification().lookupFacet(ProjectionFacet.class)
-        .map(projectionFacet->projectionFacet.projected(objectAdapter))
-        .orElse(objectAdapter);
+            .map(projectionFacet->projectionFacet.projected(objectAdapter))
+            .orElse(objectAdapter);
     }
 
     public Optional<PromptStyle> promptStyle(final ObjectFeature feature) {
         return feature.lookupFacet(PromptStyleFacet.class)
-        .map(PromptStyleFacet::value);
+            .map(PromptStyleFacet::value);
     }
 
     public PromptStyle promptStyleOrElse(final ObjectFeature feature, final PromptStyle fallback) {
         return Facets.promptStyle(feature)
-        .map(promptStyle->
-            promptStyle == PromptStyle.AS_CONFIGURED
-            ? fallback
-            : promptStyle)
-        .orElse(fallback);
+            .map(promptStyle->
+                promptStyle == PromptStyle.AS_CONFIGURED
+                ? fallback
+                : promptStyle)
+            .orElse(fallback);
     }
 
     public Optional<ObjectSpecification> elementSpec(final FacetHolder facetHolder) {
         return facetHolder.lookupFacet(TypeOfFacet.class)
-        .map(TypeOfFacet::elementSpec);
+            .map(TypeOfFacet::elementSpec);
     }
 
     public Optional<ResolvedType> typeOfAnyCardinality(final FacetHolder facetHolder) {
         return facetHolder.lookupFacet(TypeOfFacet.class)
-        .map(TypeOfFacet::value);
+            .map(TypeOfFacet::value);
     }
 
     public OptionalInt typicalLength(
@@ -388,9 +389,9 @@ public final class Facets {
             final int paramIndex) {
         val objectSpec = param.getElementType();
         return objectSpec.valueFacet()
-        .<ObjectAction>flatMap(valueFacet->
-            valueFacet.selectCompositeValueMixinForParameter(
-                    parameterNegotiationModel,paramIndex));
+            .<ObjectAction>flatMap(valueFacet->
+                valueFacet.selectCompositeValueMixinForParameter(
+                        parameterNegotiationModel,paramIndex));
     }
 
     @SuppressWarnings("unchecked")
@@ -399,26 +400,26 @@ public final class Facets {
             final ManagedProperty managedProperty) {
         val objectSpec = prop.getElementType();
         return objectSpec.valueFacet()
-        .<ObjectAction>flatMap(valueFacet->
-            valueFacet.selectCompositeValueMixinForProperty(managedProperty));
+            .<ObjectAction>flatMap(valueFacet->
+                valueFacet.selectCompositeValueMixinForProperty(managedProperty));
     }
 
     @SuppressWarnings("unchecked")
     public <X> Stream<X> valueStreamSemantics(
             final ObjectSpecification objectSpec, final Class<X> requiredType) {
         return objectSpec.valueFacet()
-        .map(valueFacet->valueFacet.streamValueSemantics(requiredType))
-        .orElseGet(Stream::empty);
+            .map(valueFacet->valueFacet.streamValueSemantics(requiredType))
+            .orElseGet(Stream::empty);
     }
 
     @SuppressWarnings("unchecked")
     public <X> boolean valueHasSemantics(
             final ObjectSpecification objectSpec, final Class<X> requiredType) {
         return objectSpec.valueFacet()
-        .map(valueFacet->valueFacet.streamValueSemantics(requiredType)
-                .findFirst()
-                .isPresent())
-        .orElse(false);
+            .map(valueFacet->valueFacet.streamValueSemantics(requiredType)
+                    .findFirst()
+                    .isPresent())
+            .orElse(false);
     }
 
     @SuppressWarnings("unchecked")
@@ -426,9 +427,9 @@ public final class Facets {
             final ObjectSpecification objectSpec,
             final Class<X> requiredType) {
         return objectSpec.valueFacet()
-        .filter(typeGuard(requiredType))
-        .flatMap(ValueFacet::selectDefaultSemantics)
-        .map(_Casts::uncheckedCast);
+            .filter(typeGuard(requiredType))
+            .flatMap(ValueFacet::selectDefaultSemantics)
+            .map(_Casts::uncheckedCast);
     }
 
     @SuppressWarnings("unchecked")
@@ -436,17 +437,25 @@ public final class Facets {
             final ObjectSpecification objectSpec,
             final Class<X> requiredType) {
         return objectSpec.valueFacet()
-        .filter(typeGuard(requiredType))
-        .map(valueFacet->(ValueSerializer<X>)valueFacet);
+            .filter(typeGuard(requiredType))
+            .map(valueFacet->(ValueSerializer<X>)valueFacet);
     }
 
     public <X> ValueSerializer<X> valueSerializerElseFail(
             final ObjectSpecification objectSpec,
             final Class<X> requiredType) {
         return valueSerializer(objectSpec, requiredType)
-        .orElseThrow(()->_Exceptions.illegalArgument(
-                "ObjectSpec is expected to have a ValueFacet<%s>",
-                objectSpec.getCorrespondingClass().getName()));
+            .orElseThrow(()->_Exceptions.illegalArgument(
+                    "ObjectSpec is expected to have a ValueFacet<%s>",
+                    objectSpec.getCorrespondingClass().getName()));
+    }
+
+    @SuppressWarnings("unchecked")
+    public Optional<TemporalValueSemantics<?>> valueTemporalSemantics(final ObjectSpecification objectSpec) {
+        return objectSpec.valueFacet()
+            .flatMap(valueFacet->valueFacet.getAllValueSemantics().stream()
+                    .findFirst())
+            .flatMap(valueSemantics->_Casts.castTo(TemporalValueSemantics.class, valueSemantics));
     }
 
     // -- HELPER

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarFragmentFactory.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarFragmentFactory.java
@@ -214,7 +214,9 @@ public class ScalarFragmentFactory {
     public static enum InputFragment {
         TEXT("fragment-input-text"),
         TEXTAREA("fragment-input-textarea"),
-        DATE("fragment-input-date"),
+        TEMPORAL("fragment-input-temporal"),
+        TEMPORAL_WITH_OFFSET("fragment-input-temporal-with-offset"),
+        TEMPORAL_WITH_ZONE("fragment-input-temporal-with-zone"),
         CHECKBOX("fragment-input-checkbox"),
         FILE("fragment-input-file"),
         SELECT_VALUE("fragment-input-select_value"),

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
@@ -157,7 +157,7 @@
 			<input wicket:id="scalarValue"
 				type="text" name="scalarValue"
 				class="form-control form-control-sm scalarValue fragment-input-date"/>
-			<div class="input-group">
+			<div class="input-group input-group-sm">
 			    <span class="input-group-text">Offset:</span>
 				<select class="form-control" wicket:id="timeoffset" name="timeoffset" data-noreset="true" style="width: auto;" />
 			</div>	
@@ -167,7 +167,7 @@
 			<input wicket:id="scalarValue"
 				type="text" name="scalarValue"
 				class="form-control form-control-sm scalarValue fragment-input-date"/>
-			<div class="input-group">
+			<div class="input-group input-group-sm">
 			    <span class="input-group-text">Zone:</span>
 				<select class="form-control" wicket:id="timezone" name="timezone" data-noreset="true" style="width: auto;" />
 			</div>	

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
@@ -147,10 +147,40 @@
          	</span>
 		</wicket:fragment>
 
-		<wicket:fragment wicket:id="fragment-input-date">
+		<wicket:fragment wicket:id="fragment-input-temporal">
 			<input wicket:id="scalarValue"
 				type="text" name="scalarValue"
 				class="form-control form-control-sm scalarValue fragment-input-date"/>
+		</wicket:fragment>
+		
+		<wicket:fragment wicket:id="fragment-input-temporal-with-offset">
+			<input wicket:id="scalarValue"
+				type="text" name="scalarValue"
+				class="form-control form-control-sm scalarValue fragment-input-date"/>
+			<div class="input-group">
+			    <span class="input-group-text" id="datetimepickerZoneZ">Offset:</span>
+			    <select class="form-control" name="timezone" data-noreset="true" id="offset-select" style="width: auto;">
+					<option selected="selected" value="">Select offset ..</option>
+					<option value="169">0</option>
+					<option value="482">+1</option>
+					<option value="489">-1</option>
+			    </select>
+			</div>	
+		</wicket:fragment>
+		
+		<wicket:fragment wicket:id="fragment-input-temporal-with-zone">
+			<input wicket:id="scalarValue"
+				type="text" name="scalarValue"
+				class="form-control form-control-sm scalarValue fragment-input-date"/>
+			<div class="input-group">
+			    <span class="input-group-text" id="datetimepickerZoneZ">Zone:</span>
+			    <select class="form-control" name="timezone" data-noreset="true" id="timezone-select" style="width: auto;">
+					<option selected="selected" value="">Select timezone ..</option>
+					<option value="169">America/New_York</option>
+					<option value="482">Europe/Vienna</option>
+					<option value="489">GB</option>
+			    </select>
+			</div>	
 		</wicket:fragment>
 
 		<wicket:fragment wicket:id="fragment-input-select_value">

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
@@ -158,7 +158,7 @@
 				type="text" name="scalarValue"
 				class="form-control form-control-sm scalarValue fragment-input-date"/>
 			<div class="input-group">
-			    <span class="input-group-text" id="datetimepickerZoneZ">Offset:</span>
+			    <span class="input-group-text">Offset:</span>
 			    <select class="form-control" name="timezone" data-noreset="true" id="offset-select" style="width: auto;">
 					<option selected="selected" value="">Select offset ..</option>
 					<option value="169">0</option>
@@ -173,7 +173,9 @@
 				type="text" name="scalarValue"
 				class="form-control form-control-sm scalarValue fragment-input-date"/>
 			<div class="input-group">
-			    <span class="input-group-text" id="datetimepickerZoneZ">Zone:</span>
+			    <span class="input-group-text">Zone:</span>
+				<select class="form-control" wicket:id="timezone" name="timezone" data-noreset="true" style="width: auto;" />
+				
 			    <select class="form-control" name="timezone" data-noreset="true" id="timezone-select" style="width: auto;">
 					<option selected="selected" value="">Select timezone ..</option>
 					<option value="169">America/New_York</option>

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
@@ -159,12 +159,7 @@
 				class="form-control form-control-sm scalarValue fragment-input-date"/>
 			<div class="input-group">
 			    <span class="input-group-text">Offset:</span>
-			    <select class="form-control" name="timezone" data-noreset="true" id="offset-select" style="width: auto;">
-					<option selected="selected" value="">Select offset ..</option>
-					<option value="169">0</option>
-					<option value="482">+1</option>
-					<option value="489">-1</option>
-			    </select>
+				<select class="form-control" wicket:id="timeoffset" name="timeoffset" data-noreset="true" style="width: auto;" />
 			</div>	
 		</wicket:fragment>
 		
@@ -175,13 +170,6 @@
 			<div class="input-group">
 			    <span class="input-group-text">Zone:</span>
 				<select class="form-control" wicket:id="timezone" name="timezone" data-noreset="true" style="width: auto;" />
-				
-			    <select class="form-control" name="timezone" data-noreset="true" id="timezone-select" style="width: auto;">
-					<option selected="selected" value="">Select timezone ..</option>
-					<option value="169">America/New_York</option>
-					<option value="482">Europe/Vienna</option>
-					<option value="489">GB</option>
-			    </select>
 			</div>	
 		</wicket:fragment>
 

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelTextFieldAbstract.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelTextFieldAbstract.java
@@ -87,7 +87,7 @@ extends ScalarPanelFormFieldAbstract<T> {
 
     @Override
     protected final FormComponent<T> createFormComponent(final String id, final ScalarModel scalarModel) {
-        formField = createTextField(id);
+        this.formField = createTextField(id);
         formField.setOutputMarkupId(true);
         return applyFormComponentAttributes(formField);
     }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelTextFieldAbstract.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelTextFieldAbstract.java
@@ -26,6 +26,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.util.convert.IConverter;
 
 import org.apache.causeway.commons.internal.assertions._Assert;
+import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.viewer.commons.model.components.UiString;
 import org.apache.causeway.viewer.wicket.model.models.ScalarModel;
 import org.apache.causeway.viewer.wicket.ui.components.scalars.ScalarFragmentFactory.InputFragment;
@@ -65,6 +66,11 @@ extends ScalarPanelFormFieldAbstract<T> {
      * Optionally the {@link IConverter} that is used for the either regular (editing) or compact (HTML) view of the panel.
      */
     protected abstract Optional<IConverter<T>> converter();
+
+    protected final IConverter<T> converterElseFail() {
+        return converter().orElseThrow(()->
+            _Exceptions.illegalState("framework bug: %s requires a converter", this.getClass().getSimpleName()));
+    }
 
     // --
 

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelTextFieldWithTemporalPicker.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelTextFieldWithTemporalPicker.java
@@ -24,6 +24,8 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
 import org.apache.wicket.markup.html.form.TextField;
 
+import org.apache.causeway.applib.value.semantics.TemporalValueSemantics;
+import org.apache.causeway.applib.value.semantics.TemporalValueSemantics.OffsetCharacteristic;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.core.metamodel.util.Facets;
 import org.apache.causeway.viewer.wicket.model.models.ScalarModel;
@@ -82,7 +84,20 @@ extends ScalarPanelTextFieldWithValueSemantics<T>  {
 
     @Override
     protected Optional<InputFragment> getInputFragmentType() {
-        return Optional.of(InputFragment.DATE);
+        final OffsetCharacteristic offsetCharacteristic =
+            Facets.valueTemporalSemantics(scalarModel().getElementType())
+                .map(TemporalValueSemantics::getOffsetCharacteristic)
+                .orElse(OffsetCharacteristic.LOCAL);
+
+        switch (offsetCharacteristic) {
+        case OFFSET:
+            return Optional.of(InputFragment.TEMPORAL_WITH_OFFSET);
+        case ZONED:
+            return Optional.of(InputFragment.TEMPORAL_WITH_ZONE);
+        case LOCAL:
+        default:
+            return Optional.of(InputFragment.TEMPORAL);
+        }
     }
 
     @Override

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelTextFieldWithTemporalPicker.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelTextFieldWithTemporalPicker.java
@@ -31,7 +31,6 @@ import org.apache.wicket.model.PropertyModel;
 
 import org.apache.causeway.applib.value.semantics.TemporalValueSemantics;
 import org.apache.causeway.applib.value.semantics.TemporalValueSemantics.OffsetCharacteristic;
-import org.apache.causeway.applib.value.semantics.TemporalValueSemantics.TemporalCharacteristic;
 import org.apache.causeway.commons.internal.base._Casts;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.core.metamodel.util.Facets;
@@ -138,11 +137,6 @@ extends ScalarPanelTextFieldWithValueSemantics<T>  {
         return _Casts.uncheckedCast(Facets.valueTemporalSemantics(scalarModel().getElementType())
                 .orElseThrow(()->_Exceptions.illegalState("no (temporal) value semantics found for %s",
                         scalarModel().getElementType())));
-    }
-
-    //TODO[CAUSEWAY-3489] unused
-    private TemporalCharacteristic temporalCharacteristic() {
-        return temporalValueSemantics().getTemporalCharacteristic();
     }
 
     private OffsetCharacteristic offsetCharacteristic() {

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/datepicker/TemporalDecomposition.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/datepicker/TemporalDecomposition.java
@@ -1,0 +1,157 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.viewer.wicket.ui.components.scalars.datepicker;
+
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.util.Locale;
+
+import org.apache.wicket.util.convert.ConversionException;
+import org.apache.wicket.util.convert.IConverter;
+
+import org.apache.causeway.applib.value.semantics.TemporalValueSemantics;
+import org.apache.causeway.applib.value.semantics.TemporalValueSemantics.OffsetCharacteristic;
+import org.apache.causeway.applib.value.semantics.TemporalValueSemantics.TemporalCharacteristic;
+import org.apache.causeway.commons.internal.base._Temporals;
+import org.apache.causeway.core.metamodel.commons.ViewOrEditMode;
+import org.apache.causeway.core.metamodel.interactions.managed.ManagedValue;
+import org.apache.causeway.core.metamodel.object.MmUnwrapUtils;
+import org.apache.causeway.viewer.wicket.model.models.ScalarModel;
+import org.apache.causeway.viewer.wicket.model.value.ConverterBasedOnValueSemantics;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Introduced to handle temporal values with zone or offset information
+ * based on existing widgets, that do not support zone or offset information.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class TemporalDecomposition<T extends Temporal> implements IConverter<T> {
+    private static final long serialVersionUID = 1L;
+
+    public static <T extends Temporal> TemporalDecomposition<T> create(final Class<T> type,
+            final ScalarModel scalarModel,
+            final TemporalValueSemantics<T> temporalValueSemantics,
+            final ConverterBasedOnValueSemantics<T> fullConverter) {
+
+        var baseEditingPattern = fullConverter.getEditingPattern();
+        //TODO[CAUSEWAY-3489] switch on offsetCharacteristic and temporalCharacteristic to do this properly
+        var editingPattern = scalarModel.isEditingMode()
+            ? "yyyy-MM-dd HH:mm:ss" // strip 'XXX' or 'VV';
+            : baseEditingPattern;
+
+        var tempDecomp = new TemporalDecomposition<>(type, temporalValueSemantics, fullConverter,
+                scalarModel.getViewOrEditMode(),
+                editingPattern);
+        tempDecomp.initFrom(scalarModel.proposedValue());
+        return tempDecomp;
+    }
+
+    private final @NonNull Class<T> type;
+    private final @NonNull TemporalValueSemantics<T> temporalValueSemantics;
+    private final @NonNull ConverterBasedOnValueSemantics<T> fullConverter;
+    private final @NonNull ViewOrEditMode viewOrEditMode;
+
+    @Getter
+    private final String editingPattern;
+
+    private void initFrom(final ManagedValue proposedValue) {
+        var temporalValue = MmUnwrapUtils.single(proposedValue.getValue().getValue());
+        if(temporalValue instanceof ZonedDateTime) {
+            var zonedDateTime = (ZonedDateTime) temporalValue;
+            this.zoneId = zonedDateTime.getZone();
+        } else if(temporalValue instanceof OffsetDateTime) {
+            var offsetDateTime = (OffsetDateTime) temporalValue;
+            this.zoneOffset = offsetDateTime.getOffset();
+        } else if(temporalValue instanceof OffsetTime) {
+            var offsetTime = (OffsetTime) temporalValue;
+            this.zoneOffset = offsetTime.getOffset();
+        }
+    }
+
+    @Override
+    public T convertToObject(final String noZoneValue, final Locale locale) throws ConversionException {
+        var fullTemporalString = noZoneValue + getZoneOrOffsetSuffix();
+        return fullConverter.convertToObject(fullTemporalString, locale);
+    }
+    @Override
+    public String convertToString(final T value, final Locale locale) {
+        return fullConverter.convertToString(value, locale);
+    }
+
+    // -- SPECIALIZATION
+
+    private TemporalCharacteristic temporalCharacteristic() {
+        return temporalValueSemantics.getTemporalCharacteristic();
+    }
+
+    private OffsetCharacteristic offsetCharacteristic() {
+        return temporalValueSemantics.getOffsetCharacteristic();
+    }
+
+    private String getZoneOrOffsetSuffix() {
+        switch (offsetCharacteristic()) {
+        case OFFSET:
+            return " " + _Temporals.formatZoneId(zoneOffset==null
+                    ? ZoneOffset.UTC
+                    : zoneOffset,
+                _Temporals.ISO_OFFSET_ONLY_FORMAT);
+        case ZONED:
+            return " " + _Temporals.formatZoneId(zoneId==null
+                    ? ZoneOffset.UTC
+                    : zoneId);
+        default:
+            return "";
+        }
+    }
+
+    // -- PROPERTIES
+
+    private ZoneId zoneId;
+    public ZoneId getZoneId() {
+        //TODO[CAUSEWAY-3489] remove debug line
+        System.err.printf("getZoneId %s%n", zoneId);
+        return zoneId;
+    }
+    public void setZoneId(final ZoneId zoneId) {
+        this.zoneId = zoneId;
+        //TODO[CAUSEWAY-3489] remove debug line
+        System.err.printf("setZoneId %s%n", zoneId);
+    }
+
+    private ZoneOffset zoneOffset;
+    public ZoneOffset getZoneOffset() {
+        //TODO[CAUSEWAY-3489] remove debug line
+        System.err.printf("getZoneOffset %s%n", zoneOffset);
+        return zoneOffset;
+    }
+    public void setZoneOffset(final ZoneOffset zoneOffset) {
+        this.zoneOffset = zoneOffset;
+       //TODO[CAUSEWAY-3489] remove debug line
+        System.err.printf("setZoneOffset %s%n", zoneOffset);
+    }
+
+}

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/datepicker/TextFieldWithDateTimePicker.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/datepicker/TextFieldWithDateTimePicker.java
@@ -132,12 +132,12 @@ extends TextFieldWithConverter<T> {
     // -- HELPER
 
     private DateTimeConfig createDatePickerConfig(
-            final MetaModelContext commonContext,
+            final MetaModelContext mmc,
             final String temporalPattern,
             final boolean isInputNullable) {
         val config = new DateTimeConfig();
 
-        config.useLocale(commonContext.currentUserLocale()
+        config.useLocale(mmc.currentUserLocale()
                 .map(UserLocale::getLanguageLocale)
                 .orElse(Locale.US));
 
@@ -176,7 +176,7 @@ extends TextFieldWithConverter<T> {
                 .useCloseIcon(FontAwesome6IconType.check_s)
                 );
 
-        val causewayDatePickerConfig = commonContext.getConfiguration().getViewer().getWicket().getDatePicker();
+        val causewayDatePickerConfig = mmc.getConfiguration().getViewer().getWicket().getDatePicker();
 
         //XXX future extensions might allow to set bounds on a per member basis (via ValueSemantics annotation)
         config.minDate(causewayDatePickerConfig.getMinDate());

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/datepicker/TextFieldWithDateTimePicker.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/datepicker/TextFieldWithDateTimePicker.java
@@ -27,12 +27,11 @@ import java.util.Optional;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
+import org.apache.wicket.model.IModel;
 import org.apache.wicket.util.convert.IConverter;
 
 import org.apache.causeway.applib.locale.UserLocale;
 import org.apache.causeway.core.metamodel.context.MetaModelContext;
-import org.apache.causeway.viewer.wicket.model.models.ScalarModel;
-import org.apache.causeway.viewer.wicket.model.value.ConverterBasedOnValueSemantics;
 import org.apache.causeway.viewer.wicket.ui.components.text.TextFieldWithConverter;
 
 import lombok.NonNull;
@@ -63,16 +62,17 @@ extends TextFieldWithConverter<T> {
 
     public TextFieldWithDateTimePicker(
             final @NonNull String id,
-            final @NonNull ScalarModel scalarModel,
+            final @NonNull IModel<T> model,
             final @NonNull Class<T> type,
-            final @NonNull IConverter<T> converter) {
-        super(id, scalarModel.unwrapped(type), type, Optional.of(converter));
+            final boolean isRequired,
+            final @NonNull IConverter<T> converter,
+            final @NonNull String editingPattern) {
+        super(id, model, type, Optional.of(converter));
         setOutputMarkupId(true);
 
         this.config = createDatePickerConfig(
-                scalarModel.getMetaModelContext(),
-                ((ConverterBasedOnValueSemantics<T>) converter).getEditingPattern(),
-                !scalarModel.isRequired());
+                editingPattern,
+                !isRequired);
 
         /* debug
                 new IConverter<T>() {
@@ -132,10 +132,10 @@ extends TextFieldWithConverter<T> {
     // -- HELPER
 
     private DateTimeConfig createDatePickerConfig(
-            final MetaModelContext mmc,
             final String temporalPattern,
             final boolean isInputNullable) {
         val config = new DateTimeConfig();
+        val mmc = MetaModelContext.instanceElseFail();
 
         config.useLocale(mmc.currentUserLocale()
                 .map(UserLocale::getLanguageLocale)

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/pages/login/SignInPanelAbstract.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/pages/login/SignInPanelAbstract.java
@@ -19,23 +19,19 @@
 package org.apache.causeway.viewer.wicket.ui.pages.login;
 
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.authentication.IAuthenticationStrategy;
 import org.apache.wicket.authroles.authentication.AuthenticatedWebSession;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.CheckBox;
-import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.PasswordTextField;
 import org.apache.wicket.markup.html.form.StatelessForm;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
-import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.request.resource.JavaScriptResourceReference;
 import org.apache.wicket.request.resource.ResourceReference;
@@ -43,6 +39,8 @@ import org.apache.wicket.util.cookies.CookieUtils;
 
 import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.core.metamodel.context.HasMetaModelContext;
+import org.apache.causeway.core.metamodel.valuesemantics.temporal.ZonedDateTimeValueSemantics;
+import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 import lombok.Getter;
 import lombok.NonNull;
@@ -266,20 +264,11 @@ implements HasMetaModelContext {
             add(new TextField<>("username").setRequired(true));
             add(new PasswordTextField("password"));
 
-            add(new DropDownChoice<ZoneId>("timezone",
+            add(Wkt.dropDownChoice("timezone",
                     new PropertyModel<ZoneId>(SignInPanelAbstract.this, "timezone"),
-                    new LoadableDetachableModel<List<ZoneId>>() {
-                        private static final long serialVersionUID = 1L;
-                        @Override
-                        protected List<ZoneId> load() {
-                            return ZoneId.getAvailableZoneIds().stream()
-                                    .sorted()
-                                    .map(ZoneId::of)
-                                    .collect(Collectors.toList());
-                        }
-                    })
-                    .setRequired(true)
-                    .setMarkupId(TIME_ZONE_SELECT));
+                    new ZonedDateTimeValueSemantics().getAvailableZoneIds())
+                .setRequired(true)
+                .setMarkupId(TIME_ZONE_SELECT));
 
             // container for remember me checkbox
             WebMarkupContainer rememberMeContainer = new WebMarkupContainer("rememberMeContainer");

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
@@ -56,6 +56,7 @@ import org.apache.wicket.markup.html.form.Button;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.FormComponent;
+import org.apache.wicket.markup.html.form.FormComponentUpdatingBehavior;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.form.upload.FileUpload;
@@ -619,12 +620,21 @@ public class Wkt {
         return new DropDownChoice<T>(id, model, choices);
     }
 
-    public <T extends Serializable> DropDownChoice<T> dropDownChoiceAdd(
+    public <T extends Serializable> DropDownChoice<T> dropDownChoiceWithAjaxUpdate(final String id,
+            final IModel<T> model,
+            final List<? extends T> choices) {
+        var component = dropDownChoice(id, model, choices);
+        component.setOutputMarkupId(true);
+        component.add(new FormComponentUpdatingBehavior());
+        return component;
+    }
+
+    public <T extends Serializable> DropDownChoice<T> dropDownChoiceWithAjaxUpdateAdd(
             final MarkupContainer container,
             final String id,
             final IModel<T> model,
             final List<? extends T> choices) {
-        return add(container, dropDownChoice(id, model, choices));
+        return add(container, dropDownChoiceWithAjaxUpdate(id, model, choices));
     }
 
     // -- FILE DOWNLOAD

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
@@ -21,6 +21,7 @@ package org.apache.causeway.viewer.wicket.ui.util;
 import static de.agilecoders.wicket.jquery.JQuery.$;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -52,6 +53,7 @@ import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Button;
+import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.TextArea;
@@ -607,6 +609,14 @@ public class Wkt {
 
     public ResourceLinkVolatile downloadLinkNoCache(final String id, final IResource resourceModel) {
         return new ResourceLinkVolatile(id, resourceModel);
+    }
+
+    // -- DROPDOWN CHOICE
+
+    public <T extends Serializable> DropDownChoice<T> dropDownChoice(final String id,
+            final IModel<T> model,
+            final List<? extends T> choices) {
+        return new DropDownChoice<T>(id, model, choices);
     }
 
     // -- FILE DOWNLOAD
@@ -1176,6 +1186,5 @@ public class Wkt {
             tag.put("disabled", "disabled");
         }
     }
-
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
@@ -619,6 +619,14 @@ public class Wkt {
         return new DropDownChoice<T>(id, model, choices);
     }
 
+    public <T extends Serializable> DropDownChoice<T> dropDownChoiceAdd(
+            final MarkupContainer container,
+            final String id,
+            final IModel<T> model,
+            final List<? extends T> choices) {
+        return add(container, dropDownChoice(id, model, choices));
+    }
+
     // -- FILE DOWNLOAD
 
     /**

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/WktComponents.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/WktComponents.java
@@ -18,6 +18,8 @@
  */
 package org.apache.causeway.viewer.wicket.ui.util;
 
+import java.util.Optional;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.Page;
@@ -26,18 +28,57 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.util.lang.Args;
 
+import org.springframework.lang.Nullable;
+
+import org.apache.causeway.commons.internal.base._Strings;
 import org.apache.causeway.commons.internal.exceptions._Exceptions.FluentException;
 import org.apache.causeway.viewer.commons.model.components.UiComponentType;
 
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
 import de.agilecoders.wicket.jquery.util.Strings2;
 
-public final class WktComponents {
+@UtilityClass
+public class WktComponents {
+
+    // -- FINDING
+
+    /**
+     * Searches given container for children of given id.
+     */
+    public Optional<Component> findById(
+            final @Nullable MarkupContainer container,
+            final @Nullable String id) {
+        if(container==null
+                || _Strings.isNullOrEmpty(id)) {
+            return Optional.empty();
+        }
+        return container.streamChildren()
+                .filter(child->id.equals(child.getId()))
+                .findFirst();
+    }
+
+    /**
+     * Searches given container for children of given id
+     * and satisfying requiredType.
+     */
+    public <T extends Component> Optional<T> findById(
+            final @Nullable MarkupContainer container,
+            final @Nullable String id,
+            final @NonNull Class<T> requiredType) {
+        return findById(container, id)
+                .filter(requiredType::isInstance)
+                .map(requiredType::cast);
+    }
+
+    // -- HIDING
 
     /**
      * Permanently hides by replacing with a {@link Label} that has an empty
      * string for its caption.
      */
-    public static void permanentlyHide(final MarkupContainer container, final String... ids) {
+    public void permanentlyHide(final MarkupContainer container, final String... ids) {
         for (final String id : ids) {
             permanentlyHideSingle(container, id);
         }
@@ -46,7 +87,7 @@ public final class WktComponents {
     /**
      * @see #permanentlyHide(MarkupContainer, String...)
      */
-    public static void permanentlyHide(final MarkupContainer container, final UiComponentType... componentIds) {
+    public void permanentlyHide(final MarkupContainer container, final UiComponentType... componentIds) {
         for (final UiComponentType uiComponentType : componentIds) {
             permanentlyHideSingle(container, uiComponentType.getId());
         }
@@ -56,7 +97,7 @@ public final class WktComponents {
      * Not overloaded because - although compiles ok on JDK6u20 (Mac), fails to
      * on JDK6u18 (Ubuntu)
      */
-    private static void permanentlyHideSingle(final MarkupContainer container, final String id) {
+    private void permanentlyHideSingle(final MarkupContainer container, final String id) {
         final WebMarkupContainer invisible = new WebMarkupContainer(id);
         invisible.setVisible(false);
         container.addOrReplace(invisible);
@@ -66,7 +107,7 @@ public final class WktComponents {
      * Sets the visibility of the child component(s) within the supplied
      * container.
      */
-    public static void setVisible(final MarkupContainer container, final boolean visibility, final String... ids) {
+    public void setVisible(final MarkupContainer container, final boolean visibility, final String... ids) {
         for (final String id : ids) {
             setVisible(container, visibility, id);
         }
@@ -75,26 +116,26 @@ public final class WktComponents {
     /**
      * @see #setVisible(MarkupContainer, boolean, String...)
      */
-    public static void setVisible(final MarkupContainer container, final boolean visibility, final UiComponentType... componentTypes) {
+    public void setVisible(final MarkupContainer container, final boolean visibility, final UiComponentType... componentTypes) {
         for (final UiComponentType uiComponentType : componentTypes) {
             setVisible(container, visibility, uiComponentType.getId());
         }
     }
 
-    private static void setVisible(final MarkupContainer container, final boolean visibility, final String wicketId) {
+    private void setVisible(final MarkupContainer container, final boolean visibility, final String wicketId) {
         final Component childComponent = container.get(wicketId);
         childComponent.setVisible(visibility);
     }
 
-    public static boolean isRenderedComponent(final Component component) {
+    public boolean isRenderedComponent(final Component component) {
         return (component.getOutputMarkupId() && !(component instanceof Page));
     }
 
-    public static boolean hasPage(final Component component) {
+    public boolean hasPage(final Component component) {
         return component.findParent(Page.class)!=null;
     }
 
-    public static void addToAjaxRequest(final AjaxRequestTarget target, final Component component) {
+    public void addToAjaxRequest(final AjaxRequestTarget target, final Component component) {
 
         if (target == null || component == null) {
             return;
@@ -112,7 +153,7 @@ public final class WktComponents {
 
     }
 
-    public static CharSequence getMarkupId(final Component component) {
+    public CharSequence getMarkupId(final Component component) {
         return Strings2.getMarkupId(Args.notNull(component, "component"));
     }
 

--- a/viewers/wicket/viewer/src/main/java/org/apache/causeway/viewer/wicket/viewer/registries/components/ComponentFactoryRegistrarDefault.java
+++ b/viewers/wicket/viewer/src/main/java/org/apache/causeway/viewer/wicket/viewer/registries/components/ComponentFactoryRegistrarDefault.java
@@ -19,6 +19,7 @@
 package org.apache.causeway.viewer.wicket.viewer.registries.components;
 
 import java.io.Serializable;
+import java.time.temporal.Temporal;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,7 @@ import org.apache.causeway.applib.annotation.PriorityPrecedence;
 import org.apache.causeway.applib.value.semantics.ValueSemanticsProvider;
 import org.apache.causeway.applib.value.semantics.ValueSemanticsResolver;
 import org.apache.causeway.commons.collections.Can;
+import org.apache.causeway.commons.internal.base._Casts;
 import org.apache.causeway.commons.internal.base._NullSafe;
 import org.apache.causeway.commons.internal.functions._Predicates;
 import org.apache.causeway.core.metamodel.tabular.simple.CollectionContentsExporter;
@@ -279,6 +281,7 @@ public class ComponentFactoryRegistrarDefault implements ComponentFactoryRegistr
 
     // -- UTILTIY
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T extends Serializable> ComponentFactoryScalarTypeConstrainedAbstract
     createForValueSemantics(final ValueSemanticsProvider<T> valueSemantics) {
 
@@ -287,7 +290,7 @@ public class ComponentFactoryRegistrarDefault implements ComponentFactoryRegistr
         }
 
         if(valueSemantics.isTemporalType()) {
-            return new ScalarPanelFactoryForTemporalPicker<T>(valueSemantics.getCorrespondingClass());
+            return _Casts.uncheckedCast(new ScalarPanelFactoryForTemporalPicker(valueSemantics.getCorrespondingClass()));
         }
 
         if(valueSemantics.isCompositeType()) {
@@ -330,7 +333,7 @@ public class ComponentFactoryRegistrarDefault implements ComponentFactoryRegistr
         }
     }
 
-    public static class ScalarPanelFactoryForTemporalPicker<T extends Serializable>
+    public static class ScalarPanelFactoryForTemporalPicker<T extends Serializable & Temporal>
     extends ComponentFactoryScalarTypeConstrainedAbstract {
 
         private final Class<T> valueTypeClass;


### PR DESCRIPTION
- [x] HTML mockups
- [x] **offset** options provider
- [x] **zone** options provider
- [x] init decomposed UI fields from temporal-value-object-holder
- [x] feed back edited UI fields to temporal-value-object-holder
- [ ] zone/offset info on new temporal value should be set to current user's info from session
- [ ] clean up TODO markers