### PR TITLE
ESTUP2-668 enable bulk mode for property change audit trails

### DIFF
--- a/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/log/EntityPropertyChangeLogger.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/log/EntityPropertyChangeLogger.java
@@ -21,6 +21,8 @@ package org.apache.causeway.applib.services.publishing.log;
 import javax.annotation.Priority;
 import javax.inject.Named;
 
+import org.apache.causeway.commons.collections.Can;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -56,4 +58,8 @@ public class EntityPropertyChangeLogger implements EntityPropertyChangeSubscribe
         log.debug(entityPropertyChange.toString());
     }
 
+    @Override
+    public void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges) {
+        entityPropertyChanges.stream().map(EntityPropertyChange::toString).forEach(log::debug);
+    }
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/spi/EntityPropertyChangeSubscriber.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/spi/EntityPropertyChangeSubscriber.java
@@ -19,6 +19,7 @@
 package org.apache.causeway.applib.services.publishing.spi;
 
 import org.apache.causeway.applib.annotation.DomainObject;
+import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.having.HasEnabling;
 
 /**
@@ -48,4 +49,5 @@ public interface EntityPropertyChangeSubscriber extends HasEnabling {
      */
     void onChanging(EntityPropertyChange entityPropertyChange);
 
+    void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges);
 }

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/publish/EntityPropertyChangePublisherDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/publish/EntityPropertyChangePublisherDefault.java
@@ -27,6 +27,7 @@ import javax.inject.Named;
 import javax.inject.Provider;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
@@ -66,6 +67,9 @@ public class EntityPropertyChangePublisherDefault implements EntityPropertyChang
 
     private Can<EntityPropertyChangeSubscriber> enabledSubscribers = Can.empty();
 
+    @Value("${entity.property.change.publisher.bulk.threshold:1}")
+    private int propertyBulkThreshold;
+
     @PostConstruct
     public void init() {
         enabledSubscribers = Can.ofCollection(subscribers)
@@ -102,12 +106,17 @@ public class EntityPropertyChangePublisherDefault implements EntityPropertyChang
                     enabledSubscribers,
                     () -> getCannotPublishReason(propertyChanges)
             );
-
-            propertyChanges.forEach(propertyChange->{
-                for (val subscriber : enabledSubscribers) {
-                    subscriber.onChanging(propertyChange);
+            if(propertyChanges.size() <= propertyBulkThreshold) {
+                propertyChanges.forEach(propertyChange -> {
+                    for (val subscriber : enabledSubscribers) {
+                        subscriber.onChanging(propertyChange);
+                    }
+                });
+            } else {
+                for(val subscriber : enabledSubscribers) {
+                    subscriber.onBulkChanging(propertyChanges);
                 }
-            });
+            }
         } finally {
             _Xray.exitPublishing(xrayHandle);
         }

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepository.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepository.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import org.apache.causeway.applib.services.bookmark.Bookmark;
 import org.apache.causeway.applib.services.publishing.spi.EntityPropertyChange;
+import org.apache.causeway.commons.collections.Can;
 
 /**
  * Provides supporting functionality for querying {@link AuditTrailEntry audit trail entry} entities.
@@ -37,6 +38,8 @@ public interface AuditTrailEntryRepository {
 
 
     AuditTrailEntry createFor(final EntityPropertyChange change);
+
+    Can<AuditTrailEntry> createForBulk(final Can<EntityPropertyChange> entityPropertyChanges);
 
     Optional<AuditTrailEntry> findFirstByTarget(final Bookmark target);
 

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/spiimpl/EntityPropertyChangeSubscriberForAuditTrail.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/spiimpl/EntityPropertyChangeSubscriberForAuditTrail.java
@@ -24,6 +24,8 @@ import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.causeway.commons.collections.Can;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -70,6 +72,14 @@ public class EntityPropertyChangeSubscriberForAuditTrail implements EntityProper
             return;
         }
         auditTrailEntryRepository.createFor(entityPropertyChange);
+    }
+
+    @Override
+    public void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges) {
+        if (!isEnabled()) {
+            return;
+        }
+        auditTrailEntryRepository.createForBulk(entityPropertyChanges);
     }
 
 }


### PR DESCRIPTION
When creating new entities the amount of audit trail entries can become quite large and inserting them one by one shouldn’t be necessary when you have a bulk option in the generic repository. The insertions still are being wrapped by another transactional so there is no case of starting a transaction for every insert. It’s just a minor performance increase.