### PR TITLE
Estup2-668 adding a bulk mode for the generic repository to enable delaying commits

### DIFF
--- a/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/log/EntityPropertyChangeLogger.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/log/EntityPropertyChangeLogger.java
@@ -21,6 +21,8 @@ package org.apache.causeway.applib.services.publishing.log;
 import javax.annotation.Priority;
 import javax.inject.Named;
 
+import org.apache.causeway.commons.collections.Can;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -56,4 +58,8 @@ public class EntityPropertyChangeLogger implements EntityPropertyChangeSubscribe
         log.debug(entityPropertyChange.toString());
     }
 
+    @Override
+    public void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges) {
+        entityPropertyChanges.stream().map(EntityPropertyChange::toString).forEach(log::debug);
+    }
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/spi/EntityPropertyChangeSubscriber.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/spi/EntityPropertyChangeSubscriber.java
@@ -19,6 +19,7 @@
 package org.apache.causeway.applib.services.publishing.spi;
 
 import org.apache.causeway.applib.annotation.DomainObject;
+import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.having.HasEnabling;
 
 /**
@@ -48,4 +49,5 @@ public interface EntityPropertyChangeSubscriber extends HasEnabling {
      */
     void onChanging(EntityPropertyChange entityPropertyChange);
 
+    void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges);
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/spi/EntityPropertyChangeSubscriber.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/spi/EntityPropertyChangeSubscriber.java
@@ -49,5 +49,6 @@ public interface EntityPropertyChangeSubscriber extends HasEnabling {
      */
     void onChanging(EntityPropertyChange entityPropertyChange);
 
-    void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges);
+    default void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges) {
+    }
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/spi/EntityPropertyChangeSubscriber.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/publishing/spi/EntityPropertyChangeSubscriber.java
@@ -50,5 +50,6 @@ public interface EntityPropertyChangeSubscriber extends HasEnabling {
     void onChanging(EntityPropertyChange entityPropertyChange);
 
     default void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges) {
+        entityPropertyChanges.forEach(this::onChanging);
     }
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/repository/RepositoryService.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/repository/RepositoryService.java
@@ -85,6 +85,14 @@ public interface RepositoryService {
     <T> T detachedEntity(@NonNull T entity);
 
     /**
+     * Suspends flushing transaction for {@param object} instances until the {@param bulkMode} is turned off again.
+     * <p>
+     * Usage should be wrapped in a try {} finally {} construction.
+     *
+     */
+    <T> void setBulkMode(final T object, final Boolean bulkMode);
+
+    /**
      * Persist the specified object (or do nothing if already persistent).
      *
      * <p>

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/repository/RepositoryService.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/repository/RepositoryService.java
@@ -85,12 +85,12 @@ public interface RepositoryService {
     <T> T detachedEntity(@NonNull T entity);
 
     /**
-     * Suspends flushing transaction for {@param object} instances until the {@param bulkMode} is turned off again.
+     * Suspends flushing transaction for {@param aClass} instances until the {@param bulkMode} is turned off again.
      * <p>
      * Usage should be wrapped in a try {} finally {} construction.
      *
      */
-    <T> void setBulkMode(final T object, final Boolean bulkMode);
+    <T extends Class> void setBulkMode(final T aClass, final Boolean bulkMode);
 
     /**
      * Persist the specified object (or do nothing if already persistent).

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/repository/RepositoryService.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/repository/RepositoryService.java
@@ -20,6 +20,7 @@ package org.apache.causeway.applib.services.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 
 import org.springframework.lang.Nullable;
@@ -85,12 +86,12 @@ public interface RepositoryService {
     <T> T detachedEntity(@NonNull T entity);
 
     /**
-     * Suspends flushing transaction for {@param aClass} instances until the {@param bulkMode} is turned off again.
-     * <p>
-     * Usage should be wrapped in a try {} finally {} construction.
+     * Enables bulk mode for all {@param aClass} in {@param callable}.
+     *
+     * Used for a large collection of persist calls without calling flush.
      *
      */
-    <T extends Class> void setBulkMode(final T aClass, final Boolean bulkMode);
+    <T> T execInBulk(Callable<T> callable, Class<?>... classes);
 
     /**
      * Persist the specified object (or do nothing if already persistent).

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/repository/RepositoryService.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/repository/RepositoryService.java
@@ -86,12 +86,12 @@ public interface RepositoryService {
     <T> T detachedEntity(@NonNull T entity);
 
     /**
-     * Enables bulk mode for all {@param aClass} in {@param callable}.
+     * Enables bulk mode for all generic repository calls in {@param callable}.
      *
-     * Used for a large collection of persist calls without calling flush.
+     * Used for a large collection of generic repository calls without calling flush.
      *
      */
-    <T> T execInBulk(Callable<T> callable, Class<?>... classes);
+    <T> T execInBulk(Callable<T> callable);
 
     /**
      * Persist the specified object (or do nothing if already persistent).

--- a/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
+++ b/core/config/src/main/java/org/apache/causeway/core/config/CausewayConfiguration.java
@@ -2085,6 +2085,19 @@ public class CausewayConfiguration {
                     Mode mode = Mode.WRITE;
                 }
             }
+
+            private final EntityPropertyChangePublisher entityPropertyChangePublisher = new EntityPropertyChangePublisher();
+
+            @Data
+            public static class EntityPropertyChangePublisher {
+
+                private final Bulk bulk = new Bulk();
+
+                @Data
+                public static class Bulk {
+                    int threshold = 1;
+                }
+            }
         }
     }
 

--- a/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/publish/EntityPropertyChangePublisherDefault.java
+++ b/core/runtimeservices/src/main/java/org/apache/causeway/core/runtimeservices/publish/EntityPropertyChangePublisherDefault.java
@@ -67,7 +67,7 @@ public class EntityPropertyChangePublisherDefault implements EntityPropertyChang
 
     private Can<EntityPropertyChangeSubscriber> enabledSubscribers = Can.empty();
 
-    @Value("${entity.property.change.publisher.bulk.threshold:10}")
+    @Value("${entity.property.change.publisher.bulk.threshold:1}")
     private int propertyBulkThreshold;
 
     @PostConstruct

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepository.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepository.java
@@ -39,7 +39,9 @@ public interface AuditTrailEntryRepository {
 
     AuditTrailEntry createFor(final EntityPropertyChange change);
 
-    Can<AuditTrailEntry> createForBulk(final Can<EntityPropertyChange> entityPropertyChanges);
+    default Can<AuditTrailEntry> createForBulk(final Can<EntityPropertyChange> entityPropertyChanges) {
+        return Can.empty();
+    }
 
     Optional<AuditTrailEntry> findFirstByTarget(final Bookmark target);
 

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepository.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepository.java
@@ -40,7 +40,7 @@ public interface AuditTrailEntryRepository {
     AuditTrailEntry createFor(final EntityPropertyChange change);
 
     default Can<AuditTrailEntry> createForBulk(final Can<EntityPropertyChange> entityPropertyChanges) {
-        return Can.empty();
+        return Can.ofCollection(entityPropertyChanges.map(this::createFor).toList());
     }
 
     Optional<AuditTrailEntry> findFirstByTarget(final Bookmark target);

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepository.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepository.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import org.apache.causeway.applib.services.bookmark.Bookmark;
 import org.apache.causeway.applib.services.publishing.spi.EntityPropertyChange;
+import org.apache.causeway.commons.collections.Can;
 
 /**
  * Provides supporting functionality for querying {@link AuditTrailEntry audit trail entry} entities.
@@ -37,6 +38,8 @@ public interface AuditTrailEntryRepository {
 
 
     AuditTrailEntry createFor(final EntityPropertyChange change);
+
+    Can<AuditTrailEntry> createForBulk(final Can<EntityPropertyChange> entityPropertyChanges);
 
     Optional<AuditTrailEntry> findFirstByTarget(final Bookmark target);
 

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
@@ -22,11 +22,9 @@ package org.apache.causeway.extensions.audittrail.applib.dom;
 
 import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -72,14 +70,7 @@ public abstract class AuditTrailEntryRepositoryAbstract<E extends AuditTrailEntr
 
     @Override
     public Can<AuditTrailEntry> createForBulk(Can<EntityPropertyChange> entityPropertyChanges) {
-        Collection<AuditTrailEntry> auditTrailEntries = repositoryService.execInBulk(() -> entityPropertyChanges.stream()
-                .map(change -> {
-                    E entry = factoryService.detachedEntity(auditTrailEntryClass);
-                    entry.init(change);
-                    return repositoryService.persist(entry);
-                }).collect(Collectors.toList()), AuditTrailEntry.class
-        );
-        return Can.ofCollection(auditTrailEntries);
+        return Can.ofCollection(repositoryService.execInBulk(() -> entityPropertyChanges.map(this::createFor).toList()));
     }
 
     public Optional<AuditTrailEntry> findFirstByTarget(final Bookmark target) {

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
@@ -40,7 +40,7 @@ import org.apache.causeway.core.config.environment.CausewaySystemEnvironment;
 import lombok.val;
 
 /**
- * Provides supporting functionality for querying {@link org.apache.causeway.extensions.audittrail.applib.dom.AuditTrailEntry audit trail entry} entities.
+ * Provides supporting functionality for querying {@link AuditTrailEntry audit trail entry} entities.
  *
  * @since 2.0 {@index}
  */

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
@@ -35,7 +35,6 @@ import org.apache.causeway.applib.services.bookmark.Bookmark;
 import org.apache.causeway.applib.services.factory.FactoryService;
 import org.apache.causeway.applib.services.publishing.spi.EntityPropertyChange;
 import org.apache.causeway.applib.services.repository.RepositoryService;
-import org.apache.causeway.applib.services.xactn.TransactionService;
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.base._Casts;
 import org.apache.causeway.core.config.environment.CausewaySystemEnvironment;
@@ -53,7 +52,6 @@ public abstract class AuditTrailEntryRepositoryAbstract<E extends AuditTrailEntr
     @Inject RepositoryService repositoryService;
     @Inject FactoryService factoryService;
     @Inject CausewaySystemEnvironment causewaySystemEnvironment;
-    @Inject TransactionService transactionService;
 
     private final Class<E> auditTrailEntryClass;
 

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
@@ -24,7 +24,6 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -77,13 +76,14 @@ public abstract class AuditTrailEntryRepositoryAbstract<E extends AuditTrailEntr
     public Can<AuditTrailEntry> createForBulk(Can<EntityPropertyChange> entityPropertyChanges) {
         Collection<AuditTrailEntry> auditTrailEntries = new ArrayList<>();
         try {
+            repositoryService.setBulkMode(AuditTrailEntry.class, true);
             entityPropertyChanges.forEach(change -> {
                 E entry = factoryService.detachedEntity(auditTrailEntryClass);
                 entry.init(change);
                 auditTrailEntries.add(repositoryService.persist(entry));
             });
         } finally {
-            transactionService.flushTransaction();
+            repositoryService.setBulkMode(AuditTrailEntry.class, false);
         }
         return Can.ofCollection(auditTrailEntries);
     }

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/dom/AuditTrailEntryRepositoryAbstract.java
@@ -76,14 +76,14 @@ public abstract class AuditTrailEntryRepositoryAbstract<E extends AuditTrailEntr
     public Can<AuditTrailEntry> createForBulk(Can<EntityPropertyChange> entityPropertyChanges) {
         Collection<AuditTrailEntry> auditTrailEntries = new ArrayList<>();
         try {
-            repositoryService.setBulkMode(AuditTrailEntry.class, true);
+            repositoryService.setBulkMode(AuditTrailEntry.class, Boolean.TRUE);
             entityPropertyChanges.forEach(change -> {
                 E entry = factoryService.detachedEntity(auditTrailEntryClass);
                 entry.init(change);
                 auditTrailEntries.add(repositoryService.persist(entry));
             });
         } finally {
-            repositoryService.setBulkMode(AuditTrailEntry.class, false);
+            repositoryService.setBulkMode(AuditTrailEntry.class, Boolean.FALSE);
         }
         return Can.ofCollection(auditTrailEntries);
     }

--- a/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/spiimpl/EntityPropertyChangeSubscriberForAuditTrail.java
+++ b/extensions/security/audittrail/applib/src/main/java/org/apache/causeway/extensions/audittrail/applib/spiimpl/EntityPropertyChangeSubscriberForAuditTrail.java
@@ -24,6 +24,8 @@ import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.causeway.commons.collections.Can;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -70,6 +72,14 @@ public class EntityPropertyChangeSubscriberForAuditTrail implements EntityProper
             return;
         }
         auditTrailEntryRepository.createFor(entityPropertyChange);
+    }
+
+    @Override
+    public void onBulkChanging(Can<EntityPropertyChange> entityPropertyChanges) {
+        if (!isEnabled()) {
+            return;
+        }
+        auditTrailEntryRepository.createForBulk(entityPropertyChanges);
     }
 
 }

--- a/persistence/commons/src/main/java/org/apache/causeway/persistence/commons/integration/repository/RepositoryServiceDefault.java
+++ b/persistence/commons/src/main/java/org/apache/causeway/persistence/commons/integration/repository/RepositoryServiceDefault.java
@@ -62,14 +62,13 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.val;
-import lombok.extern.log4j.Log4j2;
 
 @Service
 @Named(CausewayModulePersistenceCommons.NAMESPACE + ".RepositoryServiceDefault")
 @Priority(PriorityPrecedence.EARLY)
 @Qualifier("Default")
 @RequiredArgsConstructor
-@Log4j2
+//@Log4j2
 public class RepositoryServiceDefault
 implements RepositoryService, HasMetaModelContext {
 
@@ -198,7 +197,7 @@ implements RepositoryService, HasMetaModelContext {
 
     @Override
     public <T> List<T> allMatches(final Query<T> query) {
-        if(autoFlush && !FlushMgmt.isAutoFlushSuppressed()) {
+        if(autoFlush && !FlushMgmt.isAutoFlushSuppressed() && !threadLocalBulkMode.get()) {
             transactionService.flushTransaction();
         }
         return submitQuery(query);

--- a/persistence/commons/src/main/java/org/apache/causeway/persistence/commons/integration/repository/RepositoryServiceDefault.java
+++ b/persistence/commons/src/main/java/org/apache/causeway/persistence/commons/integration/repository/RepositoryServiceDefault.java
@@ -122,15 +122,16 @@ implements RepositoryService, HasMetaModelContext {
     @Override
     public <T> T persistAndFlush(final T object) {
         persist(object);
-        if(!bulkModeMap.computeIfAbsent(object.getClass(), aClass -> false)) {
+        if(!bulkModeMap.getOrDefault(object.getClass(), Boolean.FALSE)) {
             transactionService.flushTransaction();
         }
         return object;
     }
 
     @Override
-    public <T> void setBulkMode(final T object, final Boolean bulkMode) {
-        if (!bulkModeMap.computeIfAbsent(object.getClass(), aClass -> bulkMode)) {
+    public <T extends Class> void setBulkMode(final T aClass, final Boolean bulkMode) {
+        bulkModeMap.computeIfAbsent(aClass, cl -> bulkMode);
+        if (!bulkMode) {
             transactionService.flushTransaction();
         }
     }

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/fixtures/EntityTestFixtures.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/fixtures/EntityTestFixtures.java
@@ -115,7 +115,8 @@ implements
     public abstract void clearRepository();
     /** usable iff a transactional context is provided by the caller */
     public abstract void add3Books();
-    public abstract void addInventory(Set<BookDto> books);
+    public abstract Object addBook(BookDto bookDto);
+    public abstract void addInventory(Set<?> books);
 
     public void clearRepositoryInBulk() {
         repository.execInBulk(()->{
@@ -128,7 +129,7 @@ implements
         repository.execInBulk(()->{
             addInventory(BookDto.samples()
                     .sorted(Comparator.comparing(BookDto::getName))
-                    .map(repository::persistAndFlush)
+                    .map(this::addBook)
                     .collect(Collectors.toSet()));
             return null;
         });

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/fixtures/EntityTestFixtures.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/fixtures/EntityTestFixtures.java
@@ -19,6 +19,7 @@
 package org.apache.causeway.testdomain.fixtures;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -114,6 +115,24 @@ implements
     public abstract void clearRepository();
     /** usable iff a transactional context is provided by the caller */
     public abstract void add3Books();
+    public abstract void addInventory(Set<BookDto> books);
+
+    public void clearRepositoryInBulk() {
+        repository.execInBulk(()->{
+            clearRepository();
+            return null;
+        });
+    }
+
+    public void add3BooksInBulk() {
+        repository.execInBulk(()->{
+            addInventory(BookDto.samples()
+                    .sorted(Comparator.comparing(BookDto::getName))
+                    .map(repository::persistAndFlush)
+                    .collect(Collectors.toSet()));
+            return null;
+        });
+    }
 
     // -- ASSERTIONS
 
@@ -227,9 +246,9 @@ implements
     public final void resetTo3Books(final Runnable onBeforeInstall) {
         isInstalled.compute(isInst->{
             interactionService.runAnonymous(()->{
-                clearRepository();
+                clearRepositoryInBulk();
                 onBeforeInstall.run();
-                add3Books();
+                add3BooksInBulk();
             });
             return false;
         });

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/jdo/JdoTestFixtures.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/jdo/JdoTestFixtures.java
@@ -18,8 +18,10 @@
  */
 package org.apache.causeway.testdomain.jdo;
 
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -72,6 +74,12 @@ public class JdoTestFixtures extends EntityTestFixtures {
         .forEach(products::add);
 
         val inventory = JdoInventory.of("Sample Inventory", products);
+        repository.persistAndFlush(inventory);
+    }
+
+    @Override
+    public void addInventory(Set<BookDto> books) {
+        val inventory = JdoInventory.of("Sample Inventory", books.stream().map(JdoBook::fromDto).collect(Collectors.toSet()));
         repository.persistAndFlush(inventory);
     }
 

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/jdo/JdoTestFixtures.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/jdo/JdoTestFixtures.java
@@ -21,7 +21,6 @@ package org.apache.causeway.testdomain.jdo;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -78,8 +77,13 @@ public class JdoTestFixtures extends EntityTestFixtures {
     }
 
     @Override
-    public void addInventory(Set<BookDto> books) {
-        val inventory = JdoInventory.of("Sample Inventory", books.stream().map(JdoBook::fromDto).collect(Collectors.toSet()));
+    public Object addBook(BookDto bookDto) {
+        return repository.persistAndFlush(JdoBook.fromDto(bookDto));
+    }
+
+    @Override
+    public void addInventory(Set<?> books) {
+        val inventory = JdoInventory.of("Sample Inventory", (Set<JdoProduct>) books);
         repository.persistAndFlush(inventory);
     }
 

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/jpa/JpaTestFixtures.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/jpa/JpaTestFixtures.java
@@ -18,8 +18,10 @@
  */
 package org.apache.causeway.testdomain.jpa;
 
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -75,6 +77,11 @@ public class JpaTestFixtures extends EntityTestFixtures {
         repository.persistAndFlush(inventory);
     }
 
+    @Override
+    public void addInventory(Set<BookDto> books) {
+        val inventory = new JpaInventory("Sample Inventory", books.stream().map(JpaBook::fromDto).collect(Collectors.toSet()));
+        repository.persistAndFlush(inventory);
+    }
 
 
 }

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/jpa/JpaTestFixtures.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/jpa/JpaTestFixtures.java
@@ -21,7 +21,6 @@ package org.apache.causeway.testdomain.jpa;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -78,8 +77,13 @@ public class JpaTestFixtures extends EntityTestFixtures {
     }
 
     @Override
-    public void addInventory(Set<BookDto> books) {
-        val inventory = new JpaInventory("Sample Inventory", books.stream().map(JpaBook::fromDto).collect(Collectors.toSet()));
+    public Object addBook(BookDto bookDto) {
+        return repository.persistAndFlush(JpaBook.fromDto(bookDto));
+    }
+
+    @Override
+    public void addInventory(Set<?> books) {
+        val inventory = new JpaInventory("Sample Inventory", (Set<JpaProduct>) books);
         repository.persistAndFlush(inventory);
     }
 

--- a/regressiontests/persistence-jpa/src/test/java/org/apache/causeway/testdomain/persistence/jpa/JpaBootstrappingTest.java
+++ b/regressiontests/persistence-jpa/src/test/java/org/apache/causeway/testdomain/persistence/jpa/JpaBootstrappingTest.java
@@ -57,7 +57,7 @@ import lombok.val;
                 Configuration_usingJpa.class,
         },
         properties = {
-                "spring.datasource.url=jdbc:h2:mem:JpaBootstrappingTest",
+                "spring.datasource.url=jdbc:h2:mem:JpaBootstrappingTest",//;TRACE_LEVEL_SYSTEM_OUT=3",
         })
 @TestPropertySource(CausewayPresets.UseLog4j2Test)
 @Transactional @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/regressiontests/publishing-jpa/src/test/java/org/apache/causeway/testdomain/publishing/jpa/JpaPropertyBulkPublishingTest.java
+++ b/regressiontests/publishing-jpa/src/test/java/org/apache/causeway/testdomain/publishing/jpa/JpaPropertyBulkPublishingTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.testdomain.publishing.jpa;
+
+import javax.inject.Inject;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+import org.apache.causeway.core.config.presets.CausewayPresets;
+import org.apache.causeway.testdomain.conf.Configuration_usingJpa;
+import org.apache.causeway.testdomain.jpa.HasPersistenceStandardJpa;
+import org.apache.causeway.testdomain.publishing.PublishingTestFactoryAbstract;
+import org.apache.causeway.testdomain.publishing.PublishingTestFactoryJpa;
+import org.apache.causeway.testdomain.publishing.conf.Configuration_usingEntityPropertyChangePublishing;
+import org.apache.causeway.testdomain.publishing.stubs.PropertyPublishingTestAbstract;
+
+@SpringBootTest(
+        classes = {
+                Configuration_usingJpa.class,
+                Configuration_usingEntityPropertyChangePublishing.class,
+                PublishingTestFactoryJpa.class,
+                //XrayEnable.class
+        },
+        properties = {
+                "logging.level.org.apache.causeway.applib.services.publishing.log.EntityPropertyChangeLogger=DEBUG",
+                "logging.level.org.springframework.orm.jpa.*=DEBUG",
+                "logging.level.org.apache.causeway.testdomain.util.rest.KVStoreForTesting=DEBUG",
+        })
+@TestPropertySource({
+    CausewayPresets.UseLog4j2Test
+})
+@DirtiesContext
+class JpaPropertyBulkPublishingTest
+extends PropertyPublishingTestAbstract
+implements HasPersistenceStandardJpa {
+
+    @Inject private PublishingTestFactoryJpa testFactory;
+
+    @Override
+    protected PublishingTestFactoryAbstract getTestFactory() {
+        return testFactory;
+    }
+
+}

--- a/regressiontests/publishing-jpa/src/test/java/org/apache/causeway/testdomain/publishing/jpa/JpaPropertySinglePublishingTest.java
+++ b/regressiontests/publishing-jpa/src/test/java/org/apache/causeway/testdomain/publishing/jpa/JpaPropertySinglePublishingTest.java
@@ -43,12 +43,13 @@ import org.apache.causeway.testdomain.publishing.stubs.PropertyPublishingTestAbs
                 "logging.level.org.apache.causeway.applib.services.publishing.log.EntityPropertyChangeLogger=DEBUG",
                 "logging.level.org.springframework.orm.jpa.*=DEBUG",
                 "logging.level.org.apache.causeway.testdomain.util.rest.KVStoreForTesting=DEBUG",
+                "causeway.core.runtimeservices.entitypropertychangepublisher.bulk.threshold=1000",
         })
 @TestPropertySource({
     CausewayPresets.UseLog4j2Test
 })
 @DirtiesContext
-class JpaPropertyPublishingTest
+class JpaPropertySinglePublishingTest
 extends PropertyPublishingTestAbstract
 implements HasPersistenceStandardJpa {
 


### PR DESCRIPTION
When handling large collections it may be beneficial to delay the commit for performance reasons.
This framework is a tread safe way to delay the committing. This only applies of the code is not used within transactional boundries already.

As an example of use the case of audit trail entry insertions in bulk is used.