### PR TITLE
ESTUP2-674: Fix css for autocomplete

### DIFF
--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/scalars/ScalarPanelFormFieldAbstract.html
@@ -179,7 +179,7 @@
 		</wicket:fragment>
 
 		<wicket:fragment wicket:id="fragment-input-select_object">
-            <span class="fragment-input-select_object">
+            <span class="fragment-input-select_object w-100">
                 <span wicket:id="entityLink" class="w-100">link or drop down</span>
                 <span wicket:id="entityTitleIfNull">(none)</span>
             </span>


### PR DESCRIPTION
As the combobox is to small in Safari this fix is needed to show the autocomplete combobox directly in the same with as the others fields in the dialog.