### PR TITLE
CAUSEWAY-3772: Sorting on a collection of view models, hitting hollow exception

### DIFF
--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/object/ManagedObjects.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/object/ManagedObjects.java
@@ -18,7 +18,6 @@
  */
 package org.apache.causeway.core.metamodel.object;
 
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -34,13 +33,11 @@ import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.functional.Try;
 import org.apache.causeway.commons.internal.base._Casts;
 import org.apache.causeway.commons.internal.base._NullSafe;
-import org.apache.causeway.commons.internal.base._Objects;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.commons.internal.reflection._GenericResolver.ResolvedMethod;
 import org.apache.causeway.core.metamodel.commons.ClassExtensions;
 import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
 import org.apache.causeway.core.metamodel.spec.ObjectSpecification;
-import org.apache.causeway.core.metamodel.spec.feature.ObjectAssociation;
 
 import lombok.NonNull;
 import lombok.val;
@@ -297,59 +294,14 @@ public final class ManagedObjects {
                     : obj.getPojo();
     }
 
-    // -- COMPARE UTILITIES
+    // -- EQUALITY
 
     public boolean pojoEquals(final @Nullable ManagedObject a, final @Nullable ManagedObject b) {
         val aPojo = MmUnwrapUtils.single(a);
         val bPojo = MmUnwrapUtils.single(b);
         return Objects.equals(aPojo, bPojo);
     }
-
-    public int compare(final @Nullable ManagedObject p, final @Nullable ManagedObject q) {
-        return NATURAL_NULL_FIRST.compare(p, q);
-    }
-
-    public Comparator<ManagedObject> orderingBy(final ObjectAssociation sortProperty, final boolean ascending) {
-
-        final Comparator<ManagedObject> comparator = ascending
-                ? NATURAL_NULL_FIRST
-                : NATURAL_NULL_FIRST.reversed();
-
-        return (p, q) -> {
-            val pSort = sortProperty.get(p, InteractionInitiatedBy.FRAMEWORK);
-            val qSort = sortProperty.get(q, InteractionInitiatedBy.FRAMEWORK);
-            return comparator.compare(pSort, qSort);
-        };
-
-    }
-
-    // -- PREDEFINED COMPARATOR
-
-    static final Comparator<ManagedObject> NATURAL_NULL_FIRST = new Comparator<ManagedObject>(){
-        @SuppressWarnings({"rawtypes" })
-        @Override
-        public int compare(final @Nullable ManagedObject a, final @Nullable ManagedObject b) {
-            val aPojo = MmUnwrapUtils.single(a);
-            val bPojo = MmUnwrapUtils.single(b);
-            if(Objects.equals(aPojo, bPojo)) {
-                return 0;
-            }
-            if((aPojo==null
-                    || aPojo instanceof Comparable)
-                && (bPojo==null
-                        || bPojo instanceof Comparable)) {
-                return _Objects.compareNullsFirst((Comparable)aPojo, (Comparable)bPojo);
-            }
-            final int hashCompare = Integer.compare(Objects.hashCode(aPojo), Objects.hashCode(bPojo));
-            if(hashCompare!=0) {
-                return hashCompare;
-            }
-            //XXX on hash-collision we return an arbitrary non-equal relation (unspecified behavior)
-            return -1;
-        }
-
-    };
-
+    
     // -- DEFAULTS UTILITIES
 
     public ManagedObject nullToEmpty(

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/object/MmSortUtils.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/object/MmSortUtils.java
@@ -1,0 +1,84 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.causeway.core.metamodel.object;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+import org.springframework.lang.Nullable;
+
+import org.apache.causeway.commons.internal.base._Objects;
+import org.apache.causeway.core.metamodel.consent.InteractionInitiatedBy;
+import org.apache.causeway.core.metamodel.spec.feature.ObjectAssociation;
+
+import lombok.val;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class MmSortUtils {
+
+    public enum SortDirection {
+        ASCENDING,
+        DESCENDING;
+    }
+
+    public Comparator<ManagedObject> orderingBy(final ObjectAssociation sortProperty, final SortDirection sortDirection) {
+        final Comparator<ManagedObject> comparator = (sortDirection != SortDirection.DESCENDING)
+                ? NATURAL_NULL_FIRST
+                : NATURAL_NULL_FIRST.reversed();
+
+        return (p, q) -> {
+            val pSort = sortProperty.get(p, InteractionInitiatedBy.FRAMEWORK);
+            val qSort = sortProperty.get(q, InteractionInitiatedBy.FRAMEWORK);
+            return comparator.compare(pSort, qSort);
+        };
+    }
+
+    public int compare(final @Nullable ManagedObject p, final @Nullable ManagedObject q) {
+        return NATURAL_NULL_FIRST.compare(p, q);
+    }
+
+    // -- PREDEFINED COMPARATOR
+
+    final Comparator<ManagedObject> NATURAL_NULL_FIRST = new Comparator<ManagedObject>(){
+        @SuppressWarnings({"rawtypes" })
+        @Override
+        public int compare(final @Nullable ManagedObject a, final @Nullable ManagedObject b) {
+            val aPojo = MmUnwrapUtils.single(a);
+            val bPojo = MmUnwrapUtils.single(b);
+            if(Objects.equals(aPojo, bPojo)) {
+                return 0;
+            }
+            if((aPojo==null
+                    || aPojo instanceof Comparable)
+                && (bPojo==null
+                        || bPojo instanceof Comparable)) {
+                return _Objects.compareNullsFirst((Comparable)aPojo, (Comparable)bPojo);
+            }
+            final int hashCompare = Integer.compare(Objects.hashCode(aPojo), Objects.hashCode(bPojo));
+            if(hashCompare!=0) {
+                return hashCompare;
+            }
+            //XXX on hash-collision we return an arbitrary non-equal relation (unspecified behavior)
+            return -1;
+        }
+
+    };
+
+}

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 import org.springframework.lang.Nullable;
 
@@ -48,7 +47,6 @@ import org.apache.causeway.core.metamodel.interactions.VisibilityContext;
 import org.apache.causeway.core.metamodel.interactions.managed.ActionInteraction;
 import org.apache.causeway.core.metamodel.interactions.managed.CollectionInteraction;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction;
-import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction.MementoForArgs;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedCollection;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedMember;
 import org.apache.causeway.core.metamodel.interactions.managed.MultiselectChoices;
@@ -71,12 +69,12 @@ implements MultiselectChoices {
     // -- FACTORIES
 
     public static DataTableInteractive empty(final ManagedMember managedMember, final Where where) {
-        return new DataTableInteractive(managedMember, where, Can::empty);
+        return new DataTableInteractive(managedMember, where, Can.empty());
     }
 
     public static DataTableInteractive forCollection(
             final ManagedCollection managedCollection) {
-        return new DataTableInteractive(managedCollection, managedCollection.getWhere(), ()->
+        return new DataTableInteractive(managedCollection, managedCollection.getWhere(),
             managedCollection
             .streamElements()
             .collect(Can.toCan()));
@@ -88,7 +86,7 @@ implements MultiselectChoices {
             final ManagedObject actionResult) {
 
         if(actionResult==null) {
-            new DataTableInteractive(managedAction, managedAction.getWhere(), Can::empty);
+            new DataTableInteractive(managedAction, managedAction.getWhere(), Can.empty());
         }
         if(!(actionResult instanceof PackedManagedObject)) {
             throw _Exceptions.unexpectedCodeReach();
@@ -97,8 +95,7 @@ implements MultiselectChoices {
         val elements = ((PackedManagedObject)actionResult).unpack();
         elements.forEach(ManagedObject::getBookmark);
 
-        return new DataTableInteractive(managedAction, managedAction.getWhere(),
-                ()->elements);
+        return new DataTableInteractive(managedAction, managedAction.getWhere(), elements);
     }
 
     // -- CONSTRUCTION
@@ -121,13 +118,13 @@ implements MultiselectChoices {
             // we need access to the owner in support of imperative title and referenced column detection
             final ManagedMember managedMember,
             final Where where,
-            final Supplier<Can<ManagedObject>> elementSupplier) {
+            final Can<ManagedObject> elements) {
 
         this.managedMember = managedMember;
         this.where = where;
 
         //dataElements = _Observables.lazy(elementSupplier);
-        dataElements = _Observables.lazy(()->elementSupplier.get().map(
+        dataElements = _Observables.lazy(()->elements.map(
             MetaModelContext.instanceElseFail()::injectServicesInto));
 
         searchArgument = _Bindables.forValue(null);
@@ -294,7 +291,8 @@ implements MultiselectChoices {
     // -- EXPORT
 
     public DataTable export() {
-        return new DataTable(getElementType(),
+        return new DataTable(
+                getElementType(),
                 getTitle().getValue(),
                 getDataColumns().getValue()
                     .map(DataColumn::getAssociationMetaModel),
@@ -304,10 +302,20 @@ implements MultiselectChoices {
                     .collect(Can.toCan()));
     }
 
+    // used internally for serialization
+    private DataTable exportAll() {
+        return new DataTable(
+                getElementType(),
+                getTitle().getValue(),
+                getDataColumns().getValue()
+                    .map(DataColumn::getAssociationMetaModel),
+                getDataElements().getValue());
+    }
+
     // -- MEMENTO
 
-    public Memento getMemento(final @Nullable ManagedAction.MementoForArgs argsMemento) {
-        return Memento.create(this, argsMemento);
+    public Memento getMemento() {
+        return Memento.create(this);
     }
 
     /**
@@ -329,19 +337,16 @@ implements MultiselectChoices {
         private static final long serialVersionUID = 1L;
 
         static Memento create(
-                final @Nullable DataTableInteractive table,
-                final @Nullable MementoForArgs argsMemento) {
-            val managedMember = table.managedMember;
-
+                final @Nullable DataTableInteractive tableInteractive) {
             return new Memento(
-                    managedMember.getIdentifier(),
-                    table.where,
-                    argsMemento);
+                    tableInteractive.managedMember.getIdentifier(),
+                    tableInteractive.where,
+                    tableInteractive.exportAll());
         }
 
-        private final Identifier featureId;
-        private final Where where;
-        private final MementoForArgs argsMemento;
+        private final @NonNull Identifier featureId;
+        private final @NonNull Where where;
+        private final @NonNull DataTable dataTable;
 
         public DataTableInteractive getDataTableModel(final ManagedObject owner) {
 
@@ -352,21 +357,14 @@ implements MultiselectChoices {
 
             val memberId = featureId.getMemberLogicalName();
 
-            if(featureId.getType().isPropertyOrCollection()) {
-                // bypass domain events
-                val collInteraction = CollectionInteraction.start(owner, memberId, where);
-                val managedColl = collInteraction.getManagedCollection().orElseThrow();
-                // invocation bypassing domain events (pass-through)
-                return new DataTableInteractive(managedColl, where, ()->
-                    managedColl.streamElements(InteractionInitiatedBy.PASS_THROUGH).collect(Can.toCan()));
-            }
-            val actionInteraction = ActionInteraction.start(owner, memberId, where);
-            val managedAction = actionInteraction.getManagedActionElseFail();
-            val args = argsMemento.getArgumentList(managedAction.getMetaModel());
-            // invocation bypassing domain events (pass-through)
-            val actionResult = managedAction.invoke(args, InteractionInitiatedBy.PASS_THROUGH)
-                    .getSuccessElseFail();
-            return forAction(managedAction, args, actionResult);
+            final ManagedMember managedMember = featureId.getType().isPropertyOrCollection()
+                    ? CollectionInteraction.start(owner, memberId, where)
+                        .getManagedCollection().orElseThrow()
+                    : ActionInteraction.start(owner, memberId, where)
+                        .getManagedActionElseFail();
+
+            return new DataTableInteractive(managedMember, where,
+                    dataTable.streamDataElements().collect(Can.toCan()));
         }
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -123,7 +123,6 @@ implements MultiselectChoices {
         this.managedMember = managedMember;
         this.where = where;
 
-        //dataElements = _Observables.lazy(elementSupplier);
         dataElements = _Observables.lazy(()->elements.map(
             MetaModelContext.instanceElseFail()::injectServicesInto));
 

--- a/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/object/ManagedObjectTest.java
+++ b/core/metamodel/src/test/java/org/apache/causeway/core/metamodel/object/ManagedObjectTest.java
@@ -242,7 +242,7 @@ class ManagedObjectTest {
                 .collect(Collectors.toList());
 
         // when, then ... if broken throws java.lang.IllegalArgumentException: Comparison method violates its general contract!
-        managedObjects.sort(ManagedObjects.NATURAL_NULL_FIRST);
+        managedObjects.sort(MmSortUtils.NATURAL_NULL_FIRST);
     }
 
 }

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -124,29 +124,4 @@ implements
         return dataTableModel;
     }
 
-    @Override
-    public final void detach() {
-        if(isDataTableModelDetachable()) {
-            // at time of writing breaks object deletion on JDO, see [CAUSEWAY-3530]
-            super.detach();
-        }
-        //FIXME[CAUSEWAY-3522]
-        // perhaps instead call bookmarkedObjectModel().detach();
-        // or add custom HOLLOW flag and mark the bookmarkedObjectModel() hollow
-    }
-
-    // -- HELPER
-
-    private final static String PROPERTY_NAME_MODEL_REUSE = "causeway.viewer.wicket.dataTableModelReuse";
-    /**
-     * when set to false, forces detach
-     * @deprecated remove this switch once we have a fix
-     */
-    @Deprecated
-    private static boolean isDataTableModelDetachable() {
-        return "false".equalsIgnoreCase(System.getenv(PROPERTY_NAME_MODEL_REUSE))
-                || "false".equalsIgnoreCase(System.getProperty(PROPERTY_NAME_MODEL_REUSE));
-    }
-
-
 }

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -67,7 +67,7 @@ implements
                 args,
                 actionResult);
 
-        val tableMemento = table.getMemento(managedAction.getMementoForArgs(args));
+        val tableMemento = table.getMemento();
 
         val model = new DataTableModelWkt(
                 bookmarkedObjectModel, actMetaModel.getFeatureIdentifier(), tableMemento);
@@ -85,7 +85,7 @@ implements
                 ManagedCollection
                 .of(bookmarkedObjectModel.getObject(), collMetaModel, Where.NOT_SPECIFIED));
 
-        val tableMemento = table.getMemento(null);
+        val tableMemento = table.getMemento();
 
         val model = new DataTableModelWkt(
                 bookmarkedObjectModel, collMetaModel.getFeatureIdentifier(), tableMemento);

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsSortableDataProvider.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsSortableDataProvider.java
@@ -20,22 +20,24 @@ package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxt
 
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxFallbackDefaultDataTable;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider;
 import org.apache.wicket.model.IModel;
 
+import org.springframework.lang.Nullable;
+
 import org.apache.causeway.applib.annotation.TableDecorator;
-import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.core.metamodel.facets.object.tabledec.TableDecoratorFacet;
-import org.apache.causeway.core.metamodel.object.ManagedObjects;
-import org.apache.causeway.core.metamodel.spec.feature.OneToOneAssociation;
+import org.apache.causeway.core.metamodel.object.MmSortUtils;
 import org.apache.causeway.core.metamodel.tabular.interactive.DataRow;
 import org.apache.causeway.core.metamodel.tabular.interactive.DataTableInteractive;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModelAbstract;
 import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
 
+import lombok.NonNull;
 import lombok.val;
 
 /**
@@ -77,26 +79,39 @@ extends SortableDataProvider<DataRow, String> {
 
     @Override
     public Iterator<DataRow> iterator(final long skip, final long limit) {
-        val visibleRows = getDataTableModel().getDataRowsFiltered().getValue();
-        return sorted(visibleRows).iterator(Math.toIntExact(skip), Math.toIntExact(limit));
+        var dataTable = getDataTableModel();
+        // honor (single) column sort (if any)
+        dataTable.getColumnSort().setValue(columnSort().orElse(null));
+        return dataTable.getDataRowsFiltered().getValue()
+                .iterator(Math.toIntExact(skip), Math.toIntExact(limit));
     }
 
     // -- HELPER
 
-    private Can<DataRow> sorted(final Can<DataRow> dataRows) {
-        val sort = getSort();
-        val sortProperty = lookupPropertyFor(sort).orElse(null);
-        if(sortProperty != null) {
-            val objComparator = ManagedObjects.orderingBy(sortProperty, sort.isAscending());
-            return dataRows.sorted((a, b)->objComparator.compare(a.getRowElement(), b.getRowElement()));
-        }
-        return dataRows;
+    private Optional<DataTableInteractive.ColumnSort> columnSort() {
+        val sortParam = getSort();
+        return lookupColumnIndexFor(sortParam).stream()
+                .mapToObj(columnIndex->
+                    new DataTableInteractive.ColumnSort(columnIndex, sortDirection(sortParam)))
+                .findFirst();
     }
 
-    private Optional<OneToOneAssociation> lookupPropertyFor(final SortParam<String> sort) {
-        return Optional.ofNullable(sort)
-        .map(SortParam::getProperty)
-        .flatMap(getDataTableModel().getElementType()::getProperty);
+    private OptionalInt lookupColumnIndexFor(final @Nullable SortParam<String> sortParam) {
+        if(sortParam==null) return OptionalInt.empty();
+        int columnIndex = 0;
+        for(var column : getDataTableModel().getDataColumns().getValue()) {
+            if(column.getAssociationMetaModel().getId().equals(sortParam.getProperty())) {
+                return OptionalInt.of(columnIndex);
+            }
+            ++columnIndex;
+        }
+        return OptionalInt.empty();
+    }
+
+    private static MmSortUtils.SortDirection sortDirection(final @NonNull SortParam<String> sortParam) {
+        return sortParam.isAscending()
+                ? MmSortUtils.SortDirection.ASCENDING
+                : MmSortUtils.SortDirection.DESCENDING;
     }
 
 }


### PR DESCRIPTION
- [x] move sorting responsibility from Wicket Viewer to `DataTableInteractive`
- [x] unrelated bug: cannot use action memento to recreate table; requires memento of table data, that is bookmarks for each row
- [ ] find a solution for the entity hollow bug