### PR TITLE
CAUSEWAY-3772: preserve selected table rows when sorting

### DIFF
--- a/api/applib/src/main/java/module-info.java
+++ b/api/applib/src/main/java/module-info.java
@@ -97,6 +97,7 @@ module org.apache.causeway.applib {
     exports org.apache.causeway.applib.services.repository;
     exports org.apache.causeway.applib.services.routing;
     exports org.apache.causeway.applib.services.scratchpad;
+    exports org.apache.causeway.applib.services.search;
     exports org.apache.causeway.applib.services.session;
     exports org.apache.causeway.applib.services.sitemap;
     exports org.apache.causeway.applib.services.sudo;

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/search/CollectionSearchService.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/search/CollectionSearchService.java
@@ -19,9 +19,7 @@
 package org.apache.causeway.applib.services.search;
 
 import java.util.Optional;
-import java.util.function.Predicate;
-
-import org.springframework.lang.Nullable;
+import java.util.function.BiPredicate;
 
 import lombok.NonNull;
 
@@ -38,19 +36,16 @@ import lombok.NonNull;
 public interface CollectionSearchService {
 
     /**
-     * Optionally returns a {@link Predicate} that filters collections
-     * of given {@code domainType} by a nullable {@code searchString},
+     * Optionally returns a {@link BiPredicate} that filters collections
+     * of given {@code domainType} by a nullable searchString,
      * based on whether the search is supported.
      * <p>
      * For example, the searchString could be parsed into tokens, and then matched against the
      * domain object's title say.
      *
      * @param domainType - entity or view-model type to be rendered as row in a table
-     * @param searchString - nullable, e.g. the searchString could be parsed into tokens, and then matched against the
-     *      domain object's title say
      */
-    <T> Optional<Predicate<T>> searchFilter(
-            @NonNull Class<T> domainType,
-            @Nullable String searchString);
+    <T> Optional<BiPredicate<T, String>> searchPredicate(
+            @NonNull Class<T> domainType);
 
 }

--- a/api/applib/src/main/java/org/apache/causeway/applib/services/search/CollectionSearchService.java
+++ b/api/applib/src/main/java/org/apache/causeway/applib/services/search/CollectionSearchService.java
@@ -48,4 +48,8 @@ public interface CollectionSearchService {
     <T> Optional<BiPredicate<T, String>> searchPredicate(
             @NonNull Class<T> domainType);
 
+    default String searchPromptPlaceholderText(final @NonNull Class<?> domainType) {
+        return "Search";
+    }
+
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ActionInteractionHead.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ActionInteractionHead.java
@@ -146,9 +146,7 @@ implements HasMetaModel<ObjectAction> {
     private Can<ManagedObject> iterate(
             final @NonNull ManagedAction managedAction,
             final @NonNull Can<ManagedObject> paramVector) {
-
         val pendingParamModel = ParameterNegotiationModel.of(managedAction, paramVector);
-
         return getMetaModel().getParameters()
             .map(param->param.getDefault(pendingParamModel));
     }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ManagedAction.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ManagedAction.java
@@ -102,12 +102,6 @@ public final class ManagedAction extends ManagedMember {
         }
         this.action = action;
         this.multiselectChoices = multiselectChoices;
-
-        //TODO[CAUSEWAY-3772] debug outdated param model
-        var tableModel = multiselectChoices;
-        if(tableModel!=null) {
-            System.err.printf("in constructor: use of outdated tableModel: %d%n", tableModel.hashCode());
-        }
     }
 
     //CAUSEWAY-2897 ... don't memoize the head, as owner might dynamically re-attach (when entity)

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ManagedAction.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ManagedAction.java
@@ -102,6 +102,12 @@ public final class ManagedAction extends ManagedMember {
         }
         this.action = action;
         this.multiselectChoices = multiselectChoices;
+
+        //TODO[CAUSEWAY-3772] debug outdated param model
+        var tableModel = multiselectChoices;
+        if(tableModel!=null) {
+            System.err.printf("in constructor: use of outdated tableModel: %d%n", tableModel.hashCode());
+        }
     }
 
     //CAUSEWAY-2897 ... don't memoize the head, as owner might dynamically re-attach (when entity)

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ParameterNegotiationModel.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/interactions/managed/ParameterNegotiationModel.java
@@ -64,7 +64,6 @@ public class ParameterNegotiationModel {
             final @NonNull ManagedAction managedAction,
             final @NonNull Can<ManagedObject> initialParamValues) {
         return new ParameterNegotiationModel(managedAction, initialParamValues);
-
     }
 
     private final @NonNull ManagedAction managedAction;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataRow.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataRow.java
@@ -19,7 +19,6 @@
 package org.apache.causeway.core.metamodel.tabular.interactive;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.binding._Bindables;
@@ -33,8 +32,6 @@ import lombok.NonNull;
 
 public class DataRow {
 
-    @Deprecated //TODO[CAUSEWAY-3772] deprecation
-    @Getter private final UUID uuid = UUID.randomUUID(); // in support of client side sorting
     @Getter private final int rowIndex;
     private final ManagedObject rowElement;
     @Getter private final BooleanBindable selectToggle;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataRow.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataRow.java
@@ -33,14 +33,18 @@ import lombok.NonNull;
 
 public class DataRow {
 
+    @Deprecated //TODO[CAUSEWAY-3772] deprecation
     @Getter private final UUID uuid = UUID.randomUUID(); // in support of client side sorting
+    @Getter private final int rowIndex;
     private final ManagedObject rowElement;
     @Getter private final BooleanBindable selectToggle;
     @Getter private final DataTableInteractive parentTable;
 
     public DataRow(
+            final int rowIndex,
             final @NonNull DataTableInteractive parentTable,
             final @NonNull ManagedObject rowElement) {
+        this.rowIndex = rowIndex;
         this.parentTable = parentTable;
         this.rowElement = rowElement;
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataRow.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataRow.java
@@ -46,17 +46,9 @@ public class DataRow {
 
         selectToggle = _Bindables.forBoolean(false);
         selectToggle.addListener((e,o,n)->{
-
             //_ToggleDebug.onSelectRowToggle(rowElement, o, n, parentTable.isToggleAllEvent.get());
-
-            if(parentTable.isToggleAllEvent.get()) {
-                return;
-            }
-            parentTable.getDataRowsSelected().invalidate();
-            // in any case, if we have a toggle state change, clear the toggle all bindable
-            parentTable.clearToggleAll();
+            parentTable.handleRowSelectToggle();
         });
-
     }
 
     public ManagedObject getRowElement() {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.adoc
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.adoc
@@ -1,0 +1,97 @@
+= Data Table Interactive
+
+:Notice: Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at. http://www.apache.org/licenses/LICENSE-2.0 . Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+`DataTableInteractive` is an interactive tabular data model where each row corresponds to a `ManagedObject`,
+which represents either a domain object or value object.
+
+[plantuml,fig-DataTableInteractive-1,svg]
+.Data Table Interactive (simplified diagram)
+----
+@startuml
+
+class DataTableInteractive {
+    managedMember: ManagedMember
+    where: Where
+    title: Observable<String>
+    dataElements: Can<ManagedObject>
+    searchArgument: Bindable<String>
+	selectAllToggle: Bindable<Boolean>
+}
+
+class ColumnSort {
+	columnIndex: int
+}
+
+enum SortDirection {
+	ASCENDING
+	DESCENDING
+}
+
+class DataColumn {
+    columnId: String 
+    associationMetaModel: ObjectAssociation
+    columnFriendlyName: Observable<String>
+    columnDescription: Observable<Optional<String>>
+}
+
+class DataRow {
+	rowElement: ManagedObject
+	selectToggle: Bindable<Boolean> 
+}
+
+DataTableInteractive ..> "*" DataColumn : "dataColumns²"
+DataTableInteractive .> "*" DataRow : "dataRowsVisible²\ndataRowsFilteredAndSorted²\ndataRowsSelected²"
+DataTableInteractive <- DataRow : "parentTable"
+
+DataTableInteractive ..> ColumnSort : "columnSort¹"
+ColumnSort --> SortDirection : "sortDirection"
+
+@enduml
+----
+
+<.> Bindable
+<.> Observable
+
+== Search Argument Interaction
+
+The model supports filtering of data rows based on a given *search argument*.
+
+[plantuml,fig-DataTableInteractive-3,svg]
+.Search Argument Interaction
+----
+@startuml
+
+:UI **search argument** change
+triggers partial page update;
+
+:update table **memento**
+with new search argument; 
+
+:tabular data model gets **recreated** from memento;
+:client's DOM gets updated and table **re-rendered**;
+
+@enduml
+----
+
+== Data Row Select Toggle Interaction
+
+The model supports selection of data rows.
+
+[plantuml,fig-DataTableInteractive-2,svg]
+.Data Row Select Toggle Interaction
+----
+@startuml
+
+:UI **row select toggle**
+triggers partial page update;
+
+:update table **memento**
+with snapshot of 
+currently selected rows;
+
+:tabular data model gets **recreated** from memento;
+:client's DOM gets updated and table **re-rendered**;
+
+@enduml
+----

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.adoc
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.adoc
@@ -95,3 +95,21 @@ currently selected rows;
 
 @enduml
 ----
+
+== Table Serialization
+
+For each collection rendered, we create an immutable `Can<ManagedObject>` 
+of elements *visible* to the end-user (based on access rights). 
+
+Lifecycle of this `Can` is for exactly one request-cycle. (This is to avoid any hollow entity state issues.)
+
+*Selection*, *sorting* and *filtering* work on top of this immutable `Can`. 
+Which are all subject to partial page updates (AJAX) and happen in their own request-cycle.
+
+Consequently it should be sufficient to serialize the table's state by memoizing the
+
+* *elements visible* as some equivalent of `List<Bookmark>`
+* *elements selected* as some equivalent of `List<Integer>` that represents indexes into the elements visible above
+* *searchArgument* as `String` used for the new table filtering SPI
+* *columnSort* as `ColumnSort` introduced to capture by which column to sort and in what direction/order
+

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.adoc
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.adoc
@@ -108,7 +108,7 @@ class Memento {
 	where: Where
 	dataTable: DataTable
 	searchArgument: String
-	selectedRowsAsIndexes: IntList
+	selectedRowIndexes: Set<Integer>
 }
 
 @enduml
@@ -125,7 +125,7 @@ Which are all subject to partial page updates (AJAX) and happen in their own req
 Consequently it should be sufficient to serialize the table's state by memoizing the
 
 * *elements* as some equivalent of `List<Bookmark>`
-* *elements selected* as some equivalent of `List<Integer>` that represents indexes into the elements (above)
+* *elements selected* as some equivalent of `Set<Integer>` that represents indexes into the elements (above)
 * *searchArgument* as `String` used for the new table filtering SPI
 * *columnSort* as `ColumnSort` introduced to capture by which column to sort and in what direction/order
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.adoc
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.adoc
@@ -57,7 +57,7 @@ ColumnSort --> SortDirection : "sortDirection"
 
 The model supports filtering of data rows based on a given *search argument*.
 
-[plantuml,fig-DataTableInteractive-3,svg]
+[plantuml,fig-DataTableInteractive-2,svg]
 .Search Argument Interaction
 ----
 @startuml
@@ -78,7 +78,7 @@ with new search argument;
 
 The model supports selection of data rows.
 
-[plantuml,fig-DataTableInteractive-2,svg]
+[plantuml,fig-DataTableInteractive-3,svg]
 .Data Row Select Toggle Interaction
 ----
 @startuml
@@ -98,8 +98,24 @@ currently selected rows;
 
 == Table Serialization
 
+[plantuml,fig-DataTableInteractive-4,svg]
+.Table Memento
+----
+@startuml
+
+class Memento {
+	featureId: Identifier
+	where: Where
+	dataTable: DataTable
+	searchArgument: String
+	selectedRowsAsIndexes: IntList
+}
+
+@enduml
+----
+
 For each collection rendered, we create an immutable `Can<ManagedObject>` 
-of elements *visible* to the end-user (based on access rights). 
+of *elements*. If those are entities, these must be live (*attached*). 
 
 Lifecycle of this `Can` is for exactly one request-cycle. (This is to avoid any hollow entity state issues.)
 
@@ -108,8 +124,8 @@ Which are all subject to partial page updates (AJAX) and happen in their own req
 
 Consequently it should be sufficient to serialize the table's state by memoizing the
 
-* *elements visible* as some equivalent of `List<Bookmark>`
-* *elements selected* as some equivalent of `List<Integer>` that represents indexes into the elements visible above
+* *elements* as some equivalent of `List<Bookmark>`
+* *elements selected* as some equivalent of `List<Integer>` that represents indexes into the elements (above)
 * *searchArgument* as `String` used for the new table filtering SPI
 * *columnSort* as `ColumnSort` introduced to capture by which column to sort and in what direction/order
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -241,7 +241,7 @@ implements MultiselectChoices {
         return getMetaModel().getElementType();
     }
 
-    //TODO[CAUSEWAY-3772] use Bookmarks instead of UUID
+    //TODO[CAUSEWAY-3772] use Bookmarks instead of UUID? But that will break
     private final Map<UUID, Optional<DataRow>> dataRowByUuidLookupCache = _Maps.newConcurrentHashMap();
     public Optional<DataRow> lookupDataRow(final @NonNull UUID uuid) {
         // lookup can be safely cached
@@ -288,7 +288,7 @@ implements MultiselectChoices {
 
     // -- TOGGLE ALL
 
-    final AtomicBoolean isToggleAllEvent = new AtomicBoolean();
+    private final AtomicBoolean isToggleAllEvent = new AtomicBoolean();
     private final AtomicBoolean isClearToggleAllEvent = new AtomicBoolean();
     public void clearToggleAll() {
         try {
@@ -317,6 +317,20 @@ implements MultiselectChoices {
                 Where.ALL_TABLES);
     }
 
+    // -- DATA ROW TOGGLE
+
+    void handleRowSelectToggle() {
+        if(isToggleAllEvent.get()) {
+            return;
+        }
+        getDataRowsSelected().invalidate();
+        // in any case, if we have a toggle state change, clear the toggle all bindable
+        clearToggleAll();
+
+        //TODO[CAUSEWAY-3772] should trigger update of the table memento
+        //memento.setSelectedRowsAsBookmarks(getSelectedRowsAsBookmarks());
+    }
+
     // -- ASSOCIATED ACTION WITH MULTI SELECT
 
     @Override
@@ -326,7 +340,7 @@ implements MultiselectChoices {
             .map(DataRow::getRowElement);
     }
 
-    private Set<Bookmark> getSelectedAsBookmarks() {
+    private Set<Bookmark> getSelectedRowsAsBookmarks() {
         return getDataRowsSelected()
                 .getValue()
                 .stream()
@@ -397,7 +411,7 @@ implements MultiselectChoices {
                     tableInteractive.where,
                     tableInteractive.exportAll(),
                     tableInteractive.searchArgument.getValue(),
-                    tableInteractive.getSelectedAsBookmarks());
+                    tableInteractive.getSelectedRowsAsBookmarks());
         }
 
         private final @NonNull Identifier featureId;

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -326,9 +326,6 @@ implements MultiselectChoices {
         getDataRowsSelected().invalidate();
         // in any case, if we have a toggle state change, clear the toggle all bindable
         clearToggleAll();
-
-        //TODO[CAUSEWAY-3772] should trigger update of the table memento
-        //memento.setSelectedRowsAsBookmarks(getSelectedRowsAsBookmarks());
     }
 
     // -- ASSOCIATED ACTION WITH MULTI SELECT
@@ -340,7 +337,7 @@ implements MultiselectChoices {
             .map(DataRow::getRowElement);
     }
 
-    private Set<Bookmark> getSelectedRowsAsBookmarks() {
+    public Set<Bookmark> getSelectedRowsAsBookmarks() {
         return getDataRowsSelected()
                 .getValue()
                 .stream()

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -140,8 +140,6 @@ implements MultiselectChoices {
             final Where where,
             final Can<ManagedObject> elements) {
 
-        System.err.printf("------------------ new DataTableInteractive %s %d%n", managedMember.getIdentifier(), this.hashCode()); //TODO[CAUSEWAY-3772] debug
-
         val mmc = MetaModelContext.instanceElseFail();
 
         this.managedMember = managedMember;
@@ -196,7 +194,6 @@ implements MultiselectChoices {
         });
 
         searchArgument.addListener((e,o,n)->{
-            System.err.printf("search: %s->%s%n", o, n); //TODO[CAUSEWAY-3772] remove debug line
             dataRowsFilteredAndSorted.invalidate();
         });
 
@@ -258,7 +255,6 @@ implements MultiselectChoices {
     // -- SEARCH
 
     private Predicate<DataRow> adaptSearchPredicate() {
-        System.err.printf("adaptSearchPredicate (execute search)%n"); //TODO[CAUSEWAY-3772] remove debug line
         return searchPredicate==null
                 ? dataRow->true
                 : dataRow->searchPredicate
@@ -307,10 +303,8 @@ implements MultiselectChoices {
     public void doProgrammaticToggle(final @NonNull Runnable runnable) {
         try {
             isProgrammaticToggle.set(true);
-            System.err.printf("Programmatic Toggle START %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug Programmatic Toggle START
             runnable.run();
         } finally {
-            System.err.printf("Programmatic Toggle END %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug Programmatic Toggle END
             isProgrammaticToggle.set(false);
             invalidateSelectionThenNotifyListeners();
         }
@@ -320,9 +314,6 @@ implements MultiselectChoices {
 
     void handleRowSelectToggle() {
         if(isProgrammaticToggle.get()) return;
-
-        System.err.printf("handleRowSelectToggle %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug handleRowSelectToggle
-
         // in any case, if we have a toggle state change, clear the toggle all bindable
         clearToggleAll();
         invalidateSelectionThenNotifyListeners();
@@ -356,10 +347,8 @@ implements MultiselectChoices {
 
     @Override
     public Can<ManagedObject> getSelected() {
-        var selected = dataRowsSelected.getValue()
+        return dataRowsSelected.getValue()
             .map(DataRow::getRowElement);
-        System.err.printf("getSelected(%d)-> %s%n", this.hashCode(), selected); //TODO[CAUSEWAY-3772] debug table model getSelected()
-        return selected;
     }
 
     public Set<Integer> getSelectedRowIndexes() {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -63,9 +63,11 @@ import org.apache.causeway.core.metamodel.spec.feature.ObjectMember;
 import org.apache.causeway.core.metamodel.tabular.simple.DataTable;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.val;
 
 public class DataTableInteractive
@@ -173,6 +175,7 @@ implements MultiselectChoices {
         });
 
         searchArgument.addListener((e,o,n)->{
+            System.err.printf("search: %s->%s%n", o, n); //TODO[CAUSEWAY-3772] remove debug line
             dataRowsFiltered.invalidate();
             dataRowsSelected.invalidate();
         });
@@ -358,7 +361,7 @@ implements MultiselectChoices {
      * <p>
      * However, we keep track of the argument list here.
      */
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Memento implements Serializable {
         private static final long serialVersionUID = 1L;
 
@@ -369,14 +372,19 @@ implements MultiselectChoices {
                     tableInteractive.where,
                     tableInteractive.exportAll(),
                     tableInteractive.searchArgument.getValue(),
-                    Can.empty() //FIXME - flesh out
+                    Can.empty() //TODO[CAUSEWAY-3772] use model actually
                     );
         }
 
         private final @NonNull Identifier featureId;
         private final @NonNull Where where;
         private final @NonNull DataTable dataTable;
-        private final @Nullable String searchArgument;
+
+        /**
+         * Exposed as setter,
+         * such that we don't need to recreate the entire memento, just because the searchArgument has changed.
+         */
+        @Setter private @Nullable String searchArgument;
         private final @Nullable Can<Bookmark> selected;
 
         public DataTableInteractive getDataTableModel(final ManagedObject owner) {
@@ -400,11 +408,12 @@ implements MultiselectChoices {
             dataTableInteractive.searchArgument.setValue(searchArgument);
             dataTableInteractive.dataRowsFiltered.getValue()
                 .forEach(dataRow->{
-                    System.err.printf("%s%n", "set toggle");
-                    dataRow.getSelectToggle().setValue(true);
+                    System.err.printf("%s%n", "set toggle"); //TODO[CAUSEWAY-3772] remove debug line
+                    dataRow.getSelectToggle().setValue(true); //TODO[CAUSEWAY-3772] use model actually
                 });
             return dataTableInteractive;
         }
+
     }
 
 }

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -308,10 +308,10 @@ implements MultiselectChoices {
     public void whileToggleAllDo(final @NonNull Runnable runnable) {
         try {
             isToggleAllEvent.set(true);
-            System.err.printf("ToggleAll START %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug
+            System.err.printf("ToggleAll START %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug ToggleAll START
             runnable.run();
         } finally {
-            System.err.printf("ToggleAll END %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug
+            System.err.printf("ToggleAll END %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug ToggleAll END
             isToggleAllEvent.set(false);
         }
     }
@@ -321,7 +321,7 @@ implements MultiselectChoices {
     void handleRowSelectToggle() {
         if(isToggleAllEvent.get()) return;
 
-        System.err.printf("handleRowSelectToggle %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug
+        System.err.printf("handleRowSelectToggle %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug handleRowSelectToggle
 
         // in any case, if we have a toggle state change, clear the toggle all bindable
         clearToggleAll();
@@ -358,7 +358,7 @@ implements MultiselectChoices {
     public Can<ManagedObject> getSelected() {
         var selected = dataRowsSelected.getValue()
             .map(DataRow::getRowElement);
-        System.err.printf("getSelected(%d)-> %s%n", this.hashCode(), selected); //TODO[CAUSEWAY-3772] debug
+        System.err.printf("getSelected(%d)-> %s%n", this.hashCode(), selected); //TODO[CAUSEWAY-3772] debug table model getSelected()
         return selected;
     }
 

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -87,7 +87,6 @@ implements MultiselectChoices {
 
     public static DataTableInteractive forAction(
             final ManagedAction managedAction,
-            final Can<ManagedObject> args,
             final ManagedObject actionResult) {
 
         if(actionResult==null) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -324,7 +324,7 @@ implements MultiselectChoices {
 
         System.err.printf("handleRowSelectToggle %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug
 
-        getDataRowsSelected().invalidate();
+        dataRowsSelected.invalidate();
         // in any case, if we have a toggle state change, clear the toggle all bindable
         clearToggleAll();
         notifySelectionChangeListeners();
@@ -357,17 +357,15 @@ implements MultiselectChoices {
 
     @Override
     public Can<ManagedObject> getSelected() {
-        return getDataRowsSelected()
-            .getValue()
+        return dataRowsSelected.getValue()
             .map(DataRow::getRowElement);
     }
 
     public Set<Integer> getSelectedRowIndexes() {
-        return getDataRowsSelected()
-                .getValue()
-                .stream()
-                .map(DataRow::getRowIndex)
-                .collect(Collectors.toSet());
+        return dataRowsSelected.getValue()
+            .stream()
+            .map(DataRow::getRowIndex)
+            .collect(Collectors.toSet());
     }
 
     public ActionInteraction startAssociatedActionInteraction(final String actionId, final Where where) {

--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/tabular/interactive/DataTableInteractive.java
@@ -190,11 +190,10 @@ implements MultiselectChoices {
             //_Debug.onClearToggleAll(o, isAllOn, isClearToggleAllEvent.get());
             if(isClearToggleAllEvent.get()) return;
 
-            dataRowsSelected.invalidate();
             whileToggleAllDo(()->{
                 dataRows.getValue().forEach(dataRow->dataRow.getSelectToggle().setValue(isAllOn));
             });
-            notifySelectionChangeListeners();
+            invalidateSelectionThenNotifyListeners();
         });
 
         searchArgument.addListener((e,o,n)->{
@@ -324,14 +323,14 @@ implements MultiselectChoices {
 
         System.err.printf("handleRowSelectToggle %d%n", this.hashCode()); //TODO[CAUSEWAY-3772] debug
 
-        dataRowsSelected.invalidate();
         // in any case, if we have a toggle state change, clear the toggle all bindable
         clearToggleAll();
-        notifySelectionChangeListeners();
+        invalidateSelectionThenNotifyListeners();
     }
 
-    public void notifySelectionChangeListeners() {
+    public void invalidateSelectionThenNotifyListeners() {
         // simply toggles the boolean value, to trigger any listeners
+        dataRowsSelected.invalidate();
         selectionChanges.setValue(!selectionChanges.getValue());
     }
 
@@ -357,8 +356,10 @@ implements MultiselectChoices {
 
     @Override
     public Can<ManagedObject> getSelected() {
-        return dataRowsSelected.getValue()
+        var selected = dataRowsSelected.getValue()
             .map(DataRow::getRowElement);
+        System.err.printf("getSelected(%d)-> %s%n", this.hashCode(), selected); //TODO[CAUSEWAY-3772] debug
+        return selected;
     }
 
     public Set<Integer> getSelectedRowIndexes() {

--- a/extensions/vw/fullcalendar/wicket/ui/src/main/java/org/apache/causeway/extensions/fullcalendar/wkt/ui/viewer/CalendaredCollectionAbstract.java
+++ b/extensions/vw/fullcalendar/wicket/ui/src/main/java/org/apache/causeway/extensions/fullcalendar/wkt/ui/viewer/CalendaredCollectionAbstract.java
@@ -81,7 +81,7 @@ extends PanelAbstract<DataTableInteractive, EntityCollectionModel> {
         config.setSelectable(true);
         config.setAllDaySlot(true);
 
-        final Iterable<ManagedObject> entityList = model.getDataTableModel().getDataRowsFiltered().getValue()
+        final Iterable<ManagedObject> entityList = model.getDataTableModel().getDataRowsFilteredAndSorted().getValue()
                 .map(DataRow::getRowElement);
         final Iterable<String> calendarNames = getCalendarNames(entityList);
 

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/util/interaction/DataTableTester.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/util/interaction/DataTableTester.java
@@ -46,7 +46,7 @@ public class DataTableTester {
 
     public void assertFilteredDataElements(final List<Object> expectedPojoElements) {
         assertEquals(expectedPojoElements,
-                dataTable.getDataRowsFiltered().getValue()
+                dataTable.getDataRowsFilteredAndSorted().getValue()
                 .map(DataRow::getRowElement)
                 .map(MmUnwrapUtils::single).toList());
     }
@@ -62,7 +62,7 @@ public class DataTableTester {
             final List<Integer> toggleOnIndices,
             final List<Object> expectedPojoElements) {
         toggleOnIndices.forEach(index->
-            dataTable.getDataRowsFiltered().getValue().getElseFail(index).getSelectToggle().setValue(true));
+            dataTable.getDataRowsFilteredAndSorted().getValue().getElseFail(index).getSelectToggle().setValue(true));
         assertSelectedDataElements(expectedPojoElements);
     }
 
@@ -70,13 +70,13 @@ public class DataTableTester {
             final List<Integer> toggleOffIndices,
             final List<Object> expectedPojoElements) {
         toggleOffIndices.forEach(index->
-            dataTable.getDataRowsFiltered().getValue().getElseFail(index).getSelectToggle().setValue(false));
+            dataTable.getDataRowsFilteredAndSorted().getValue().getElseFail(index).getSelectToggle().setValue(false));
         assertSelectedDataElements(expectedPojoElements);
     }
 
     public void assertDataRowSelectionIsAll() {
         assertEquals(
-                dataTable.getDataRowsFiltered().getValue()
+                dataTable.getDataRowsFilteredAndSorted().getValue()
                 .map(DataRow::getRowElement)
                 .map(MmUnwrapUtils::single).toList(),
                 dataTable.getDataRowsSelected().getValue()

--- a/regressiontests/base/src/main/java/org/apache/causeway/testdomain/util/interaction/DomainObjectTesterFactory.java
+++ b/regressiontests/base/src/main/java/org/apache/causeway/testdomain/util/interaction/DomainObjectTesterFactory.java
@@ -574,7 +574,6 @@ public class DomainObjectTesterFactory implements HasMetaModelContext {
 
         }
 
-
         public Can<Command> getCapturedCommands() {
             return Can.ofCollection(capturedCommands);
         }
@@ -610,7 +609,7 @@ public class DomainObjectTesterFactory implements HasMetaModelContext {
                 val actionResult = resultOrVeto.getSuccessElseFail();
 
                 val table = DataTableInteractive
-                        .forAction(managedAction, pendingArgs.getParamValues(), actionResult);
+                        .forAction(managedAction, actionResult);
 
                 return DataTableTester.of(table);
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModel.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModel.java
@@ -126,12 +126,6 @@ extends
         return getDataTableModel().getTableDecoratorIfAny();
     }
 
-    /**
-     * On end-user searchArgument changes via UI,
-     * update the underlying table memento and propagate to backend models.
-     */
-    void setSearchArgument(final String searchArg);
-
     // -- PARENTED SPECIFICS
 
     @Deprecated // there is no reason to distinguish parented and standalone, I think

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModel.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModel.java
@@ -107,8 +107,11 @@ extends
 
     // -- BASIC PROPERTIES
 
+    /**
+     * Element count after filtering.
+     */
     default int getElementCount() {
-        return getDataTableModel().getElementCount();
+        return getDataTableModel().getFilteredElementCount();
     }
 
     default String getName() {

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModel.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModel.java
@@ -123,6 +123,12 @@ extends
         return getDataTableModel().getTableDecoratorIfAny();
     }
 
+    /**
+     * On end-user searchArgument changes via UI,
+     * update the underlying table memento and propagate to backend models.
+     */
+    void setSearchArgument(final String searchArg);
+
     // -- PARENTED SPECIFICS
 
     @Deprecated // there is no reason to distinguish parented and standalone, I think

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModelAbstract.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModelAbstract.java
@@ -86,11 +86,6 @@ implements EntityCollectionModel {
         return delegate().getBookmarkedOwner();
     }
 
-    @Override
-    public final void setSearchArgument(final String searchArg) {
-        delegate().setSearchArgument(searchArg);
-    }
-
     // -- VARIANT SUPPORT
 
     @Override

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModelAbstract.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModelAbstract.java
@@ -70,11 +70,6 @@ implements EntityCollectionModel {
         return getObject();
     }
 
-//XXX experiments from CausewayWicketApplication_experimental
-//    public final void setDataTableModel(final DataTableModel dataTableModel) {
-//        delegate().setObject(dataTableModel);
-//    }
-
     @Override
     public ObjectMember getMetaModel() {
         return getDataTableModel()
@@ -89,6 +84,11 @@ implements EntityCollectionModel {
     @Override
     public final ManagedObject getParentObject() {
         return delegate().getBookmarkedOwner();
+    }
+
+    @Override
+    public final void setSearchArgument(final String searchArg) {
+        delegate().setSearchArgument(searchArg);
     }
 
     // -- VARIANT SUPPORT

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModelStandalone.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/EntityCollectionModelStandalone.java
@@ -18,8 +18,6 @@
  */
 package org.apache.causeway.viewer.wicket.model.models;
 
-import org.apache.causeway.commons.collections.Can;
-import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.object.PackedManagedObject;
 import org.apache.causeway.viewer.wicket.model.models.interaction.BookmarkedObjectWkt;
 import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataTableModelWkt;
@@ -36,8 +34,7 @@ extends EntityCollectionModelAbstract {
 
     public static EntityCollectionModelStandalone forActionModel(
             final @NonNull PackedManagedObject collectionAsAdapter,
-            final @NonNull ActionModel actionModel,
-            final @NonNull Can<ManagedObject> args) {
+            final @NonNull ActionModel actionModel) {
 
         val action = actionModel.getAction();
 
@@ -46,7 +43,6 @@ extends EntityCollectionModelAbstract {
                         BookmarkedObjectWkt
                             .ofAdapter(actionModel.getParentObject()),
                         action,
-                        args,
                         collectionAsAdapter));
     }
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/act/ActionInteractionWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/act/ActionInteractionWkt.java
@@ -148,8 +148,6 @@ extends HasBookmarkedOwnerAbstract<ActionInteraction> {
         }
 
         if(associatedWithCollectionIfAny!=null) {
-            var table = associatedWithCollectionIfAny.getDataTableModel();
-            System.err.printf("ActionInteraction %s %d%n", "calls load()", table.hashCode()); //TODO[CAUSEWAY-3772] debug
             return ActionInteraction.startWithMultiselect(getBookmarkedOwner(), memberId, where,
                     associatedWithCollectionIfAny.getDataTableModel());
         }
@@ -164,7 +162,6 @@ extends HasBookmarkedOwnerAbstract<ActionInteraction> {
     }
 
     public final ActionInteraction actionInteraction() {
-        System.err.printf("ActionInteraction %s%n", "calls getObject()"); //TODO[CAUSEWAY-3772] debug
         return getObject();
     }
 
@@ -265,7 +262,8 @@ extends HasBookmarkedOwnerAbstract<ActionInteraction> {
     private ParameterNegotiationModel startParameterNegotiationModel() {
         var tableModel = actionInteraction().getManagedAction().map(ManagedAction::getMultiselectChoices);
         if(tableModel!=null) {
-            System.err.printf("possibly uses outdated tableModel - detaching: %d%n", tableModel.hashCode()); //TODO[CAUSEWAY-3772] debug
+            // possibly uses outdated tableModel, if any select toggle, filtering or sorting has happened
+            // hence detach(), so we invalidate the current actionInteraction() and force recreation
             detach();
         }
         this.parameterNegotiationModel = actionInteraction().startParameterNegotiation()

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/act/ActionInteractionWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/act/ActionInteractionWkt.java
@@ -33,6 +33,7 @@ import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.commons.internal.exceptions._Exceptions;
 import org.apache.causeway.core.metamodel.interactions.managed.ActionInteraction;
+import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction;
 import org.apache.causeway.core.metamodel.interactions.managed.ParameterNegotiationModel;
 import org.apache.causeway.core.metamodel.interactions.managed.PendingParamsSnapshot;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
@@ -147,6 +148,8 @@ extends HasBookmarkedOwnerAbstract<ActionInteraction> {
         }
 
         if(associatedWithCollectionIfAny!=null) {
+            var table = associatedWithCollectionIfAny.getDataTableModel();
+            System.err.printf("ActionInteraction %s %d%n", "calls load()", table.hashCode()); //TODO[CAUSEWAY-3772] debug
             return ActionInteraction.startWithMultiselect(getBookmarkedOwner(), memberId, where,
                     associatedWithCollectionIfAny.getDataTableModel());
         }
@@ -161,6 +164,7 @@ extends HasBookmarkedOwnerAbstract<ActionInteraction> {
     }
 
     public final ActionInteraction actionInteraction() {
+        System.err.printf("ActionInteraction %s%n", "calls getObject()"); //TODO[CAUSEWAY-3772] debug
         return getObject();
     }
 
@@ -259,6 +263,11 @@ extends HasBookmarkedOwnerAbstract<ActionInteraction> {
      * Start and transiently memoize a new {@link ParameterNegotiationModel}.
      */
     private ParameterNegotiationModel startParameterNegotiationModel() {
+        var tableModel = actionInteraction().getManagedAction().map(ManagedAction::getMultiselectChoices);
+        if(tableModel!=null) {
+            System.err.printf("possibly uses outdated tableModel - detaching: %d%n", tableModel.hashCode()); //TODO[CAUSEWAY-3772] debug
+            detach();
+        }
         this.parameterNegotiationModel = actionInteraction().startParameterNegotiation()
                 .orElseThrow(()->_Exceptions.noSuchElement(memberId));
         this.pendingParamsSnapshot = parameterNegotiationModel.createSnapshotModel();

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataRowWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataRowWkt.java
@@ -19,7 +19,6 @@
 package org.apache.causeway.viewer.wicket.model.models.interaction.coll;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.apache.wicket.model.ChainingModel;
 import org.apache.wicket.model.IModel;
@@ -42,7 +41,7 @@ extends ChainingModel<DataRow> {
         return new DataRowWkt(dataTableModelHolder, dataRow);
     }
 
-    @Getter private final @NonNull UUID uuid; // in support of table sorting
+    @Getter private final int rowIndex;
     @Getter private final @NonNull DataRowToggleWkt dataRowToggle;
 
     private transient DataRow dataRow;
@@ -52,14 +51,14 @@ extends ChainingModel<DataRow> {
             final DataRow dataRow) {
         super(dataTableModelHolder);
         this.dataRow = dataRow;
-        this.uuid = dataRow.getUuid();
+        this.rowIndex = dataRow.getRowIndex();
         this.dataRowToggle = new DataRowToggleWkt(this);
     }
 
     @Override
     public final DataRow getObject() {
         if(dataRow==null) {
-            dataRow = getDataTableModel().lookupDataRow(uuid)
+            dataRow = getDataTableModel().lookupDataRow(rowIndex)
                     .orElse(null);
             if(dataRow==null) {
                 // [CAUSEWAY-3005] UI out of sync with model: reload page
@@ -75,7 +74,7 @@ extends ChainingModel<DataRow> {
 
     public boolean hasMemoizedDataRow() {
         return dataRow!=null
-                || getDataTableModel().lookupDataRow(uuid).isPresent();
+                || getDataTableModel().lookupDataRow(rowIndex).isPresent();
     }
 
     // -- HELPER

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataRowWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataRowWkt.java
@@ -25,10 +25,8 @@ import org.apache.wicket.model.IModel;
 
 import org.apache.causeway.core.metamodel.tabular.interactive.DataRow;
 import org.apache.causeway.core.metamodel.tabular.interactive.DataTableInteractive;
-import org.apache.causeway.viewer.wicket.model.util.PageUtils;
 
 import lombok.Getter;
-import lombok.NonNull;
 
 public class DataRowWkt
 extends ChainingModel<DataRow> {
@@ -42,44 +40,30 @@ extends ChainingModel<DataRow> {
     }
 
     @Getter private final int rowIndex;
-    @Getter private final @NonNull DataRowToggleWkt dataRowToggle;
-
-    private transient DataRow dataRow;
 
     private DataRowWkt(
             final IModel<DataTableInteractive> dataTableModelHolder,
             final DataRow dataRow) {
         super(dataTableModelHolder);
-        this.dataRow = dataRow;
         this.rowIndex = dataRow.getRowIndex();
-        this.dataRowToggle = new DataRowToggleWkt(this);
     }
 
     @Override
     public final DataRow getObject() {
-        if(dataRow==null) {
-            dataRow = getDataTableModel().lookupDataRow(rowIndex)
-                    .orElse(null);
-            if(dataRow==null) {
-                // [CAUSEWAY-3005] UI out of sync with model: reload page
-                PageUtils.pageReload();
-            }
-        }
-        return dataRow;
+        return dataRow().orElse(null);
     }
 
     public Optional<DataRow> dataRow() {
-        return Optional.ofNullable(getObject());
+        return dataTableModel().lookupDataRow(rowIndex);
     }
 
     public boolean hasMemoizedDataRow() {
-        return dataRow!=null
-                || getDataTableModel().lookupDataRow(rowIndex).isPresent();
+        return ((DataTableModelWkt) super.getTarget()).isAttached();
     }
 
     // -- HELPER
 
-    private DataTableInteractive getDataTableModel() {
+    private DataTableInteractive dataTableModel() {
         return ((DataTableModelWkt) super.getTarget()).getObject();
     }
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -118,7 +118,7 @@ implements
         tableInteractive.getSearchArgument().addListener((e, o, searchArg)->{
             tableMemento.setSearchArgument(searchArg);
         });
-        tableInteractive.getDataRowsSelected().addListener((e, o, dataRowsSelected)->{
+        tableInteractive.getSelectionChanges().addListener((e, o, n)->{
             tableMemento.setSelectedRowsAsBookmarks(tableInteractive.getSelectedRowsAsBookmarks());
         });
     }

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -119,7 +119,7 @@ implements
             tableMemento.setSearchArgument(searchArg);
         });
         tableInteractive.getSelectionChanges().addListener((e, o, n)->{
-            tableMemento.setSelectedRowsAsBookmarks(tableInteractive.getSelectedRowsAsBookmarks());
+            tableMemento.setSelectedRowIndexes(tableInteractive.getSelectedRowIndexes());
         });
     }
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -18,6 +18,8 @@
  */
 package org.apache.causeway.viewer.wicket.model.models.interaction.coll;
 
+import java.util.TreeSet;
+
 import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.annotation.Where;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction;
@@ -119,7 +121,9 @@ implements
             tableMemento.setSearchArgument(searchArg);
         });
         tableInteractive.getSelectionChanges().addListener((e, o, n)->{
-            tableMemento.setSelectedRowIndexes(tableInteractive.getSelectedRowIndexes());
+            var idxs = tableInteractive.getSelectedRowIndexes();
+            System.err.printf("memoize selection %s%n", new TreeSet<>(idxs)); //TODO[CAUSEWAY-3772] debug
+            tableMemento.setSelectedRowIndexes(idxs);
         });
     }
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -20,7 +20,6 @@ package org.apache.causeway.viewer.wicket.model.models.interaction.coll;
 
 import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.annotation.Where;
-import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedCollection;
 import org.apache.causeway.core.metamodel.object.ManagedObject;
@@ -56,7 +55,6 @@ implements
     public static DataTableModelWkt forActionModel(
             final @NonNull BookmarkedObjectWkt bookmarkedObjectModel,
             final @NonNull ObjectAction actMetaModel,
-            final @NonNull Can<ManagedObject> args,
             final @NonNull ManagedObject actionResult) {
 
         val managedAction = ManagedAction
@@ -64,13 +62,10 @@ implements
 
         val table = DataTableInteractive.forAction(
                 managedAction,
-                args,
                 actionResult);
 
-        val tableMemento = table.getMemento();
-
         val model = new DataTableModelWkt(
-                bookmarkedObjectModel, actMetaModel.getFeatureIdentifier(), tableMemento);
+                bookmarkedObjectModel, actMetaModel.getFeatureIdentifier(), table.getMemento());
 
         model.setObject(table); // memoize
 
@@ -85,10 +80,8 @@ implements
                 ManagedCollection
                 .of(bookmarkedObjectModel.getObject(), collMetaModel, Where.NOT_SPECIFIED));
 
-        val tableMemento = table.getMemento();
-
         val model = new DataTableModelWkt(
-                bookmarkedObjectModel, collMetaModel.getFeatureIdentifier(), tableMemento);
+                bookmarkedObjectModel, collMetaModel.getFeatureIdentifier(), table.getMemento());
 
         model.setObject(table); // memoize
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -60,14 +60,14 @@ implements
         val managedAction = ManagedAction
                 .of(bookmarkedObjectModel.getObject(), actMetaModel, Where.NOT_SPECIFIED);
 
-        val table = DataTableInteractive.forAction(
+        val tableInteractive = DataTableInteractive.forAction(
                 managedAction,
                 actionResult);
 
         val model = new DataTableModelWkt(
-                bookmarkedObjectModel, actMetaModel.getFeatureIdentifier(), table.getMemento());
+                bookmarkedObjectModel, actMetaModel.getFeatureIdentifier(), tableInteractive.getMemento());
 
-        model.setObject(table); // memoize
+        model.setObject(tableInteractive); // memoize
 
         return model;
     }
@@ -76,14 +76,14 @@ implements
             final @NonNull BookmarkedObjectWkt bookmarkedObjectModel,
             final @NonNull OneToManyAssociation collMetaModel) {
 
-        val table = DataTableInteractive.forCollection(
+        val tableInteractive = DataTableInteractive.forCollection(
                 ManagedCollection
                 .of(bookmarkedObjectModel.getObject(), collMetaModel, Where.NOT_SPECIFIED));
 
         val model = new DataTableModelWkt(
-                bookmarkedObjectModel, collMetaModel.getFeatureIdentifier(), table.getMemento());
+                bookmarkedObjectModel, collMetaModel.getFeatureIdentifier(), tableInteractive.getMemento());
 
-        model.setObject(table); // memoize
+        model.setObject(tableInteractive); // memoize
 
         return model;
     }
@@ -115,6 +115,12 @@ implements
     protected DataTableInteractive load() {
         val dataTableModel = tableMemento.getDataTableModel(getBookmarkedOwner());
         return dataTableModel;
+    }
+
+    public void setSearchArgument(final String searchArg) {
+        tableMemento.setSearchArgument(searchArg);
+        if(!isAttached()) return;
+        getObject().getSearchArgument().setValue(searchArg);
     }
 
 }

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -18,8 +18,6 @@
  */
 package org.apache.causeway.viewer.wicket.model.models.interaction.coll;
 
-import java.util.TreeSet;
-
 import org.apache.causeway.applib.Identifier;
 import org.apache.causeway.applib.annotation.Where;
 import org.apache.causeway.core.metamodel.interactions.managed.ManagedAction;
@@ -121,9 +119,7 @@ implements
             tableMemento.setSearchArgument(searchArg);
         });
         tableInteractive.getSelectionChanges().addListener((e, o, n)->{
-            var idxs = tableInteractive.getSelectedRowIndexes();
-            System.err.printf("memoize selection %s%n", new TreeSet<>(idxs)); //TODO[CAUSEWAY-3772] debug memoize selection
-            tableMemento.setSelectedRowIndexes(idxs);
+            tableMemento.setSelectedRowIndexes(tableInteractive.getSelectedRowIndexes());
         });
     }
 

--- a/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
+++ b/viewers/wicket/model/src/main/java/org/apache/causeway/viewer/wicket/model/models/interaction/coll/DataTableModelWkt.java
@@ -122,7 +122,7 @@ implements
         });
         tableInteractive.getSelectionChanges().addListener((e, o, n)->{
             var idxs = tableInteractive.getSelectedRowIndexes();
-            System.err.printf("memoize selection %s%n", new TreeSet<>(idxs)); //TODO[CAUSEWAY-3772] debug
+            System.err.printf("memoize selection %s%n", new TreeSet<>(idxs)); //TODO[CAUSEWAY-3772] debug memoize selection
             tableMemento.setSelectedRowIndexes(idxs);
         });
     }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/actionresponse/ActionResultResponseType.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/actionresponse/ActionResultResponseType.java
@@ -31,7 +31,6 @@ import org.apache.causeway.applib.value.Blob;
 import org.apache.causeway.applib.value.Clob;
 import org.apache.causeway.applib.value.LocalResourcePath;
 import org.apache.causeway.applib.value.OpenUrlStrategy;
-import org.apache.causeway.commons.collections.Can;
 import org.apache.causeway.commons.internal.assertions._Assert;
 import org.apache.causeway.commons.internal.base._Casts;
 import org.apache.causeway.commons.internal.base._NullSafe;
@@ -63,8 +62,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             determineScalarAdapter(actionModel.getMetaModelContext(), resultAdapter); // intercepts collections
             return toEntityPage(resultAdapter);
         }
@@ -81,12 +79,11 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             _Assert.assertTrue(resultAdapter instanceof PackedManagedObject);
 
             final var collectionModel = EntityCollectionModelStandalone
-                    .forActionModel((PackedManagedObject)resultAdapter, actionModel, args);
+                    .forActionModel((PackedManagedObject)resultAdapter, actionModel);
             return ActionResultResponse.toPage(
                     StandaloneCollectionPage.class, new StandaloneCollectionPage(collectionModel));
         }
@@ -99,8 +96,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             final var valueModel = ValueModel.of(actionModel.getAction(), resultAdapter);
             valueModel.setActionHint(actionModel);
             final var valuePage = new ValuePage(valueModel);
@@ -112,8 +108,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             final Object value = resultAdapter.getPojo();
             IRequestHandler handler =
                     _DownloadHandler.downloadHandler(actionModel.getAction(), value);
@@ -125,8 +120,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             final Object value = resultAdapter.getPojo();
             IRequestHandler handler =
                     _DownloadHandler.downloadHandler(actionModel.getAction(), value);
@@ -138,8 +132,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             final LocalResourcePath localResPath = (LocalResourcePath)resultAdapter.getPojo();
             final var webAppContextPath = actionModel.getMetaModelContext().getWebAppContextPath();
             return ActionResultResponse
@@ -151,8 +144,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             // open URL server-side redirect
             final LocalResourcePath localResPath = (LocalResourcePath)resultAdapter.getPojo();
             final var webAppContextPath = actionModel.getMetaModelContext().getWebAppContextPath();
@@ -165,8 +157,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             final URL url = (URL)resultAdapter.getPojo();
             return ActionResultResponse
                     .openUrlInBrowser(target, url.toString(), OpenUrlStrategy.NEW_WINDOW); // default behavior
@@ -177,8 +168,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @NonNull ManagedObject resultAdapter,
-                final Can<ManagedObject> args) {
+                final @NonNull ManagedObject resultAdapter) {
             // open URL server-side redirect
             final Object value = resultAdapter.getPojo();
             final var webAppContextPath = actionModel.getMetaModelContext().getWebAppContextPath();
@@ -192,8 +182,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @Nullable ManagedObject resultAdapter, // arg is not used
-                final Can<ManagedObject> args) {
+                final @Nullable ManagedObject resultAdapter) {
             final VoidModel voidModel = new VoidModel();
             voidModel.setActionHint(actionModel);
             return ActionResultResponse.toPage(VoidReturnPage.class, new VoidReturnPage(voidModel));
@@ -207,8 +196,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @Nullable ManagedObject resultAdapter, // arg is not used
-                final Can<ManagedObject> args) {
+                final @Nullable ManagedObject resultAdapter) {
             val currentPage = PageRequestHandlerTracker.getLastHandler(RequestCycle.get()).getPage();
             val pageClass = currentPage.getClass();
             return ActionResultResponse.toPage(PageRedirectRequest.forPage(pageClass, _Casts.uncheckedCast(currentPage)));
@@ -219,8 +207,7 @@ public enum ActionResultResponseType {
         public ActionResultResponse interpretResult(
                 final ActionModel actionModel,
                 final AjaxRequestTarget target,
-                final @Nullable ManagedObject resultAdapter, // arg is not used
-                final Can<ManagedObject> args) {
+                final @Nullable ManagedObject resultAdapter) {
             val signInPage = actionModel.getMetaModelContext()
                     .lookupServiceElseFail(PageClassRegistry.class)
                     .getPageClass(PageType.SIGN_IN);
@@ -230,7 +217,7 @@ public enum ActionResultResponseType {
     };
 
     public abstract ActionResultResponse interpretResult(
-            ActionModel model, AjaxRequestTarget target, ManagedObject resultAdapter, Can<ManagedObject> args);
+            ActionModel model, AjaxRequestTarget target, ManagedObject resultAdapter);
 
     /**
      * Only overridden for {@link ActionResultResponseType#OBJECT object}
@@ -244,8 +231,7 @@ public enum ActionResultResponseType {
     public static ActionResultResponse determineAndInterpretResult(
             final ActionModel model,
             final AjaxRequestTarget targetIfAny,
-            final @Nullable ManagedObject resultAdapter,
-            final Can<ManagedObject> args) {
+            final @Nullable ManagedObject resultAdapter) {
 
         /*
          * XXX won't implement CAUSEWAY-3372 (reload on void action result)
@@ -261,7 +247,7 @@ public enum ActionResultResponseType {
 
         val typeAndAdapter = determineFor(resultAdapter, mapAbsentResultTo, targetIfAny);
         return typeAndAdapter.type // mapped to 'mapAbsentResultTo' if adapter is unspecified or null
-                .interpretResult(model, targetIfAny, typeAndAdapter.resultAdapter, args);
+                .interpretResult(model, targetIfAny, typeAndAdapter.resultAdapter);
     }
 
     public static ActionResultResponse toEntityPage(final @NonNull ManagedObject entityOrViewmodel) {

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable;
 
-import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
 
@@ -28,7 +27,6 @@ import org.apache.wicket.extensions.markup.html.repeater.data.table.DataTable;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.NoRecordsToolbar;
 import org.apache.wicket.markup.repeater.IItemFactory;
-import org.apache.wicket.markup.repeater.IItemReuseStrategy;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
@@ -69,7 +67,8 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
         this.toggleboxColumn = toggleboxColumn;
         setOutputMarkupId(true);
         setVersioned(false);
-        setItemReuseStrategy((IItemReuseStrategy & Serializable) CausewayAjaxDataTable::itemReuseStrategyWithCast);
+        //TODO[CAUSEWAY-3772] optimization reinstate?
+        //setItemReuseStrategy((IItemReuseStrategy & Serializable) CausewayAjaxDataTable::itemReuseStrategyWithCast);
     }
 
     public void setPageNumberHintAndBroadcast(final AjaxRequestTarget target) {
@@ -148,13 +147,13 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
             final Iterator<IModel<DataRow>> newModels,
             final Iterator<Item<DataRow>> existingItems) {
 
-        //TODO[CAUSEWAY-3772] remove map
-        val itemByUuid = _Maps.<Integer, Item<DataRow>>newHashMap();
+        //TODO[CAUSEWAY-3772] remove map?
+        val itemByRowIndex = _Maps.<Integer, Item<DataRow>>newHashMap();
         existingItems.forEachRemaining(item->{
             val model = item.getModel();
             if(model instanceof DataRowWkt) {
                 val dataRowWkt = (DataRowWkt)item.getModel();
-                itemByUuid.put(dataRowWkt.getRowIndex(), item);
+                itemByRowIndex.put(dataRowWkt.getRowIndex(), item);
             }
         });
 
@@ -169,7 +168,7 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
             @Override
             public Item<DataRow> next() {
                 final DataRowWkt newModel = (DataRowWkt)newModels.next();
-                final Item<DataRow> oldItem = itemByUuid.get(newModel.getRowIndex());
+                final Item<DataRow> oldItem = itemByRowIndex.get(newModel.getRowIndex());
 
                 final IModel<DataRow> model2 = oldItem != null
                         ? oldItem.getModel()

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable;
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -26,18 +25,14 @@ import org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.DataTable;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.NoRecordsToolbar;
-import org.apache.wicket.markup.repeater.IItemFactory;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
 
-import org.apache.causeway.commons.internal.base._Casts;
-import org.apache.causeway.commons.internal.collections._Maps;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.core.metamodel.tabular.interactive.DataRow;
 import org.apache.causeway.viewer.wicket.model.hints.UiHintContainer;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
-import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
@@ -67,7 +62,7 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
         this.toggleboxColumn = toggleboxColumn;
         setOutputMarkupId(true);
         setVersioned(false);
-        //TODO[CAUSEWAY-3772] optimization reinstate?
+        //[CAUSEWAY-3772] optimization reinstate? though I have no clue what that is doing
         //setItemReuseStrategy((IItemReuseStrategy & Serializable) CausewayAjaxDataTable::itemReuseStrategyWithCast);
     }
 
@@ -142,59 +137,58 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
         return rowElement.getSpecification().getCssClass(rowElement);
     }
 
-    private static Iterator<Item<DataRow>> itemReuseStrategy(
-            final IItemFactory<DataRow> factory,
-            final Iterator<IModel<DataRow>> newModels,
-            final Iterator<Item<DataRow>> existingItems) {
-
-        //TODO[CAUSEWAY-3772] remove map?
-        val itemByRowIndex = _Maps.<Integer, Item<DataRow>>newHashMap();
-        existingItems.forEachRemaining(item->{
-            val model = item.getModel();
-            if(model instanceof DataRowWkt) {
-                val dataRowWkt = (DataRowWkt)item.getModel();
-                itemByRowIndex.put(dataRowWkt.getRowIndex(), item);
-            }
-        });
-
-        return new Iterator<Item<DataRow>>() {
-            private int index = 0;
-
-            @Override
-            public boolean hasNext() {
-                return newModels.hasNext();
-            }
-
-            @Override
-            public Item<DataRow> next() {
-                final DataRowWkt newModel = (DataRowWkt)newModels.next();
-                final Item<DataRow> oldItem = itemByRowIndex.get(newModel.getRowIndex());
-
-                final IModel<DataRow> model2 = oldItem != null
-                        ? oldItem.getModel()
-                        : newModel;
-                return factory.newItem(index++, model2);
-            }
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-
-        };
-
-    }
-
-    @SuppressWarnings("unused")
-    private static <T> Iterator<Item<T>> itemReuseStrategyWithCast(
-            final IItemFactory<T> factory,
-            final Iterator<IModel<T>> newModels,
-            final Iterator<Item<T>> existingItems) {
-        return _Casts.uncheckedCast(itemReuseStrategy(
-                _Casts.uncheckedCast(factory),
-                _Casts.uncheckedCast(newModels),
-                _Casts.uncheckedCast(existingItems)));
-    }
+//    private static Iterator<Item<DataRow>> itemReuseStrategy(
+//            final IItemFactory<DataRow> factory,
+//            final Iterator<IModel<DataRow>> newModels,
+//            final Iterator<Item<DataRow>> existingItems) {
+//
+//        val itemByRowIndex = _Maps.<Integer, Item<DataRow>>newHashMap();
+//        existingItems.forEachRemaining(item->{
+//            val model = item.getModel();
+//            if(model instanceof DataRowWkt) {
+//                val dataRowWkt = (DataRowWkt)item.getModel();
+//                itemByRowIndex.put(dataRowWkt.getRowIndex(), item);
+//            }
+//        });
+//
+//        return new Iterator<Item<DataRow>>() {
+//            private int index = 0;
+//
+//            @Override
+//            public boolean hasNext() {
+//                return newModels.hasNext();
+//            }
+//
+//            @Override
+//            public Item<DataRow> next() {
+//                final DataRowWkt newModel = (DataRowWkt)newModels.next();
+//                final Item<DataRow> oldItem = itemByRowIndex.get(newModel.getRowIndex());
+//
+//                final IModel<DataRow> model2 = oldItem != null
+//                        ? oldItem.getModel()
+//                        : newModel;
+//                return factory.newItem(index++, model2);
+//            }
+//
+//            @Override
+//            public void remove() {
+//                throw new UnsupportedOperationException();
+//            }
+//
+//        };
+//
+//    }
+//
+//    @SuppressWarnings("unused")
+//    private static <T> Iterator<Item<T>> itemReuseStrategyWithCast(
+//            final IItemFactory<T> factory,
+//            final Iterator<IModel<T>> newModels,
+//            final Iterator<Item<T>> existingItems) {
+//        return _Casts.uncheckedCast(itemReuseStrategy(
+//                _Casts.uncheckedCast(factory),
+//                _Casts.uncheckedCast(newModels),
+//                _Casts.uncheckedCast(existingItems)));
+//    }
 
     private void honorHints() {
         headersToolbar.honourSortOrderHints();

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
@@ -185,6 +185,7 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
 
     }
 
+    @SuppressWarnings("unused")
     private static <T> Iterator<Item<T>> itemReuseStrategyWithCast(
             final IItemFactory<T> factory,
             final Iterator<IModel<T>> newModels,

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxDataTable.java
@@ -21,7 +21,6 @@ package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxt
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder;
@@ -149,12 +148,13 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
             final Iterator<IModel<DataRow>> newModels,
             final Iterator<Item<DataRow>> existingItems) {
 
-        val itemByUuid = _Maps.<UUID, Item<DataRow>>newHashMap();
+        //TODO[CAUSEWAY-3772] remove map
+        val itemByUuid = _Maps.<Integer, Item<DataRow>>newHashMap();
         existingItems.forEachRemaining(item->{
             val model = item.getModel();
             if(model instanceof DataRowWkt) {
                 val dataRowWkt = (DataRowWkt)item.getModel();
-                itemByUuid.put(dataRowWkt.getUuid(), item);
+                itemByUuid.put(dataRowWkt.getRowIndex(), item);
             }
         });
 
@@ -169,7 +169,7 @@ public class CausewayAjaxDataTable extends DataTable<DataRow, String> {
             @Override
             public Item<DataRow> next() {
                 final DataRowWkt newModel = (DataRowWkt)newModels.next();
-                final Item<DataRow> oldItem = itemByUuid.get(newModel.getUuid());
+                final Item<DataRow> oldItem = itemByUuid.get(newModel.getRowIndex());
 
                 final IModel<DataRow> model2 = oldItem != null
                         ? oldItem.getModel()

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxHeadersToolbar.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxHeadersToolbar.java
@@ -26,6 +26,7 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.causeway.commons.internal.base._Casts;
 import org.apache.causeway.viewer.wicket.model.hints.UiHintContainer;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
+import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 /**
  * Adapted from Wicket's own {@link AjaxFallbackHeadersToolbar}.
@@ -34,16 +35,16 @@ public class CausewayAjaxHeadersToolbar
 extends CausewayAjaxHeadersToolbarAbstract<String> {
 
     private static final long serialVersionUID = 1L;
-    private final CollectionContentsSortableDataProvider stateLocator;
+    private final CollectionContentsSortableDataProvider singleSortStateLocator;
     private CausewayAjaxDataTable table;
 
     public CausewayAjaxHeadersToolbar(
             final CausewayAjaxDataTable table,
-            final CollectionContentsSortableDataProvider stateLocator) {
-        super(table, _Casts.uncheckedCast(stateLocator));
+            final CollectionContentsSortableDataProvider singleSortStateLocator) {
+        super(table, _Casts.uncheckedCast(singleSortStateLocator));
         this.table = table;
-        table.setOutputMarkupId(true);
-        this.stateLocator = stateLocator;
+        this.singleSortStateLocator = singleSortStateLocator;
+        Wkt.ajaxEnable(table);
     }
 
     @Override
@@ -51,36 +52,20 @@ extends CausewayAjaxHeadersToolbarAbstract<String> {
         super.onInitialize();
     }
 
-    // //////////////////////////////////////
-
     @Override
     protected WebMarkupContainer newSortableHeader(final String borderId, final String property,
             final ISortStateLocator<String> locator) {
-        return new CausewayAjaxFallbackOrderByBorder<String>(borderId, table, property, locator/*, getAjaxCallListener()*/);
+        return new CausewayAjaxFallbackOrderByBorder<String>(borderId, table, property, locator);
     }
 
-    //    /**
-    //     * Returns a decorator that will be used to decorate ajax links used in sortable headers
-    //     *
-    //     * @return decorator or null for none
-    //     */
-    //    protected IAjaxCallListener getAjaxCallListener()
-    //    {
-    //        return null;
-    //    }
-
-    // //////////////////////////////////////
-
     void honourSortOrderHints() {
-        UiHintContainer uiHintContainer = getUiHintContainer();
-        if(uiHintContainer == null) {
-            return;
-        }
+        var uiHintContainer = getUiHintContainer();
+        if(uiHintContainer == null) return;
 
         for (SortOrder sortOrder : SortOrder.values()) {
             String property = uiHintContainer.getHint(table, sortOrder.name());
             if(property != null) {
-                stateLocator.getSortState().setPropertySortOrder(property, sortOrder);
+                singleSortStateLocator.getSortState().setPropertySortOrder(property, sortOrder);
             }
         }
     }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxNavigationToolbar.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CausewayAjaxNavigationToolbar.java
@@ -52,6 +52,12 @@ implements HasCommonContext {
         return new CausewayAjaxPagingNavigator(navigatorId, table);
     }
 
+    /* if we need to customize the navigation label, that would go here ...
+    @Override
+    protected WebComponent newNavigatorLabel(final String navigatorId, final DataTable<?, ?> table) {
+        return new NavigatorLabel(navigatorId, table);
+    }*/
+
     // -- HELPER
 
     private void addShowAllButton(final DataTable<?, ?> table) {

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.html
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.html
@@ -22,6 +22,12 @@
         <wicket:panel>
             <div class="collectionContentsAsAjaxTablePanel collectionContentsComponentType">
                 <div class="clearfix"></div>
+
+				<div class="input-group table-search-bar">
+				  <span class="input-group-text"><i class="fa-solid fa-magnifying-glass"></i></span>
+				  <input wicket:id="table-search-input" class="form-control" type="text" placeholder="Search" />
+				</div>
+				
                 <div class="table-responsive">
                     <table class="contents table table-striped table-sm table-hover table-bordered" cellspacing="0" wicket:id="table">[table]</table>
                 </div>

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
@@ -68,7 +68,7 @@ implements CollectionCountProvider {
 
     @Override
     public Integer getCount() {
-        return getModel().getDataTableModel().getElementCount();
+        return getModel().getDataTableModel().getFilteredElementCount();
     }
 
     @Override

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
@@ -46,6 +46,7 @@ import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxta
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumn;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 import org.apache.causeway.viewer.wicket.ui.panels.PanelAbstract;
+import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 import org.apache.causeway.viewer.wicket.ui.util.WktComponents;
 
 import lombok.val;
@@ -135,14 +136,20 @@ implements CollectionCountProvider {
 
     /**
      * If table quick search is supported, adds a search bar on top of the table component.
+     * @param placeholderText
      */
-    private void addSearchBar(final DataTableInteractive dataTable, final CausewayAjaxDataTable dataTableComponent) {
+    private void addSearchBar(
+            final DataTableInteractive dataTable,
+            final CausewayAjaxDataTable dataTableComponent) {
         if(!dataTable.isSearchSupported()) {
             WktComponents.permanentlyHide(this, ID_TABLE_SEARCH_INPUT);
             return;
         }
         // init searchArg from backend
         val searchBar = new TextField<>(ID_TABLE_SEARCH_INPUT, Model.of(dataTable.getSearchArgument().getValue()));
+
+        Wkt.attributeReplace(searchBar, "placeholder", dataTable.getSearchPromptPlaceholderText());
+
         searchBar.add(new OnChangeAjaxBehavior() {
             private static final long serialVersionUID = 1L;
             @Override

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
@@ -21,7 +21,10 @@ package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxt
 import java.util.List;
 
 import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
 import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxFallbackDefaultDataTable;
+import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.Model;
 
 import org.apache.causeway.commons.internal.collections._Lists;
@@ -43,6 +46,7 @@ import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxta
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.TitleColumn;
 import org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns.ToggleboxColumn;
 import org.apache.causeway.viewer.wicket.ui.panels.PanelAbstract;
+import org.apache.causeway.viewer.wicket.ui.util.WktComponents;
 
 import lombok.val;
 
@@ -56,6 +60,7 @@ implements CollectionCountProvider {
 
     private static final long serialVersionUID = 1L;
     private static final String ID_TABLE = "table";
+    private static final String ID_TABLE_SEARCH_INPUT = "table-search-input";
 
     public CollectionContentsAsAjaxTablePanel(final String id, final EntityCollectionModel model) {
         super(id, model);
@@ -113,6 +118,8 @@ implements CollectionCountProvider {
         val dataTable = new CausewayAjaxDataTable(
                 ID_TABLE, columns, dataProvider, collectionModel.getPageSize(), toggleboxColumn);
         addOrReplace(dataTable);
+
+        addSearchBar(collectionModel.getDataTableModel(), dataTable);
     }
 
     private MultiselectToggleProvider getMultiselectToggleProvider() {
@@ -124,6 +131,31 @@ implements CollectionCountProvider {
             component = component.getParent();
         }
         return null;
+    }
+
+    /**
+     * If table quick search is supported, adds a search bar on top of the table component.
+     */
+    private void addSearchBar(final DataTableInteractive dataTable, final CausewayAjaxDataTable dataTableComponent) {
+        if(!dataTable.isSearchSupported()) {
+            WktComponents.permanentlyHide(this, ID_TABLE_SEARCH_INPUT);
+            return;
+        }
+        // init searchArg from backend
+        val searchBar = new TextField<>(ID_TABLE_SEARCH_INPUT, Model.of(dataTable.getSearchArgument().getValue()));
+        searchBar.add(new OnChangeAjaxBehavior() {
+            private static final long serialVersionUID = 1L;
+            @Override
+            protected void onUpdate(final AjaxRequestTarget target) {
+                // on searchArg update originating from end-user in UI,
+                // update the backend model
+                var searchArg = searchBar.getValue();
+                entityCollectionModel().setSearchArgument(searchArg);
+                // tells the table component to re-render
+                target.add(dataTableComponent);
+            }
+        });
+        addOrReplace(searchBar);
     }
 
     private void prependTitleColumn(

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsAsAjaxTablePanel.java
@@ -157,7 +157,7 @@ implements CollectionCountProvider {
                 // on searchArg update originating from end-user in UI,
                 // update the backend model
                 var searchArg = searchBar.getValue();
-                entityCollectionModel().setSearchArgument(searchArg);
+                entityCollectionModel().getDataTableModel().getSearchArgument().setValue(searchArg);
                 // tells the table component to re-render
                 target.add(dataTableComponent);
             }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsSortableDataProvider.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/CollectionContentsSortableDataProvider.java
@@ -74,7 +74,7 @@ extends SortableDataProvider<DataRow, String> {
 
     @Override
     public long size() {
-        return getDataTableModel().getElementCount();
+        return getDataTableModel().getFilteredElementCount();
     }
 
     @Override
@@ -82,7 +82,7 @@ extends SortableDataProvider<DataRow, String> {
         var dataTable = getDataTableModel();
         // honor (single) column sort (if any)
         dataTable.getColumnSort().setValue(columnSort().orElse(null));
-        return dataTable.getDataRowsFiltered().getValue()
+        return dataTable.getDataRowsFilteredAndSorted().getValue()
                 .iterator(Math.toIntExact(skip), Math.toIntExact(limit));
     }
 

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/GenericColumnAbstract.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/GenericColumnAbstract.java
@@ -71,7 +71,7 @@ implements GenericColumn, HasMetaModelContext {
             final Item<ICellPopulator<DataRow>> cellItem,
             final String componentId,
             final IModel<DataRow> rowModel) {
-        cellItem.add(createCellComponent(componentId, rowModel.getObject(), ((DataRowWkt)rowModel).getDataRowToggle()));
+        cellItem.add(createCellComponent(componentId, (DataRowWkt)rowModel));
         if(this instanceof TitleColumn) {
             Wkt.cssAppend(cellItem, "title-column");
             if(((TitleColumn)this).isTitleSuppressed()) {
@@ -85,8 +85,7 @@ implements GenericColumn, HasMetaModelContext {
         }
     }
 
-    protected abstract Component createCellComponent(
-            final String componentId, final DataRow dataRow, IModel<Boolean> dataRowToggle);
+    protected abstract Component createCellComponent(final String componentId, final DataRowWkt dataRowWkt);
 
     protected ComponentFactory findComponentFactory(final UiComponentType uiComponentType, final IModel<?> model) {
         return getComponentRegistry().findComponentFactory(uiComponentType, model);

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/PluralColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/PluralColumn.java
@@ -32,11 +32,11 @@ import org.apache.causeway.applib.services.placeholder.PlaceholderRenderService.
 import org.apache.causeway.core.metamodel.object.ManagedObject;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
 import org.apache.causeway.core.metamodel.tabular.interactive.DataColumn;
-import org.apache.causeway.core.metamodel.tabular.interactive.DataRow;
 import org.apache.causeway.viewer.commons.model.components.UiComponentType;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.model.models.ValueModel;
+import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
 import lombok.Builder;
@@ -74,9 +74,8 @@ extends AssociationColumnAbstract {
     }
 
     @Override
-    protected Component createCellComponent(
-            final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
-
+    protected Component createCellComponent(final String componentId, final DataRowWkt dataRowWkt) {
+        val dataRow = dataRowWkt.getObject();
         val dataColumn = dataRow.lookupColumnById(memberId).orElseThrow();
         val cellElements = dataRow.getCellElementsForColumn(dataColumn);
 

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/SingularColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/SingularColumn.java
@@ -24,10 +24,10 @@ import org.apache.wicket.Component;
 import org.apache.wicket.model.IModel;
 
 import org.apache.causeway.core.metamodel.commons.ViewOrEditMode;
-import org.apache.causeway.core.metamodel.tabular.interactive.DataRow;
 import org.apache.causeway.viewer.commons.model.components.UiComponentType;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
+import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
 
 import lombok.val;
 
@@ -47,8 +47,8 @@ extends AssociationColumnAbstract {
     }
 
     @Override
-    protected Component createCellComponent(
-            final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
+    protected Component createCellComponent(final String componentId, final DataRowWkt dataRowWkt) {
+        val dataRow = dataRowWkt.getObject();
         val rowElement = dataRow.getRowElement();
         val rowElementModel = UiObjectWkt.ofAdapter(rowElement);
         val property = rowElement.getSpecification().getPropertyElseFail(memberId);

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/TitleColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/TitleColumn.java
@@ -19,17 +19,16 @@
 package org.apache.causeway.viewer.wicket.ui.components.collectioncontents.ajaxtable.columns;
 
 import org.apache.wicket.Component;
-import org.apache.wicket.model.IModel;
 
 import org.springframework.lang.Nullable;
 
 import org.apache.causeway.applib.services.bookmark.Bookmark;
 import org.apache.causeway.core.metamodel.object.ManagedObjects;
-import org.apache.causeway.core.metamodel.tabular.interactive.DataRow;
 import org.apache.causeway.viewer.commons.model.components.UiComponentType;
 import org.apache.causeway.viewer.wicket.model.models.EntityCollectionModel.Variant;
 import org.apache.causeway.viewer.wicket.model.models.UiObjectWkt;
 import org.apache.causeway.viewer.wicket.model.models.ValueModel;
+import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
 
 import lombok.val;
 
@@ -55,7 +54,8 @@ extends GenericColumnAbstract {
 
     @Override
     protected Component createCellComponent(
-            final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
+            final String componentId, final DataRowWkt dataRowWkt) {
+        val dataRow = dataRowWkt.getObject();
         val rowElement = dataRow.getRowElement();
 
         if(ManagedObjects.isValue(rowElement)) {

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
@@ -76,6 +76,8 @@ extends GenericColumnAbstract {
         Wkt.cssAppend(bulkToggle, "togglebox-column");
         return bulkToggle;
     }
+    
+    // -- HELPER
 
     private void onBulkUpdate(final Boolean isChecked, final AjaxRequestTarget target) {
         var dataTableInteractive = dataTableModelHolder.getObject();
@@ -88,7 +90,6 @@ extends GenericColumnAbstract {
             }
         });
         dataTableInteractive.notifySelectionChangeListeners();
-
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
@@ -61,9 +61,7 @@ extends GenericColumnAbstract {
 
     @Override
     protected Component createCellComponent(final String componentId, final DataRowWkt dataRowWkt) {
-        var dataRowToggle = new DataRowToggleWkt(dataRowWkt);
-        //TODO[CAUSEWAY-3772] debug createCellComponent
-        System.err.printf("createCellComponent for row %d%n", dataRowWkt.getRowIndex());
+        val dataRowToggle = new DataRowToggleWkt(dataRowWkt);
         val rowToggle = new ContainedToggleboxPanel(componentId, dataRowToggle);
         rowToggles.add(rowToggle);
         return rowToggle.setOutputMarkupId(true);

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
@@ -62,6 +62,8 @@ extends GenericColumnAbstract {
     @Override
     protected Component createCellComponent(final String componentId, final DataRowWkt dataRowWkt) {
         var dataRowToggle = new DataRowToggleWkt(dataRowWkt);
+        //TODO[CAUSEWAY-3772] debug createCellComponent
+        System.err.printf("createCellComponent for row %d%n", dataRowWkt.getRowIndex());
         val rowToggle = new ContainedToggleboxPanel(componentId, dataRowToggle);
         rowToggles.add(rowToggle);
         return rowToggle.setOutputMarkupId(true);
@@ -76,20 +78,19 @@ extends GenericColumnAbstract {
         Wkt.cssAppend(bulkToggle, "togglebox-column");
         return bulkToggle;
     }
-    
+
     // -- HELPER
 
     private void onBulkUpdate(final Boolean isChecked, final AjaxRequestTarget target) {
         var dataTableInteractive = dataTableModelHolder.getObject();
 
-        //TODO[CAUSEWAY-3772] don't trample over table model
-        dataTableInteractive.whileToggleAllDo(()->{
+        dataTableInteractive.doProgrammaticToggle(()->{
             val bulkToggle = BulkToggle.valueOf(isChecked);
             for (ContainedToggleboxPanel rowToggle : rowToggles) {
                 rowToggle.set(bulkToggle, target);
             }
         });
-        dataTableInteractive.invalidateSelectionThenNotifyListeners();
+
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
@@ -89,7 +89,7 @@ extends GenericColumnAbstract {
                 rowToggle.set(bulkToggle, target);
             }
         });
-        dataTableInteractive.notifySelectionChangeListeners();
+        dataTableInteractive.invalidateSelectionThenNotifyListeners();
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/ajaxtable/columns/ToggleboxColumn.java
@@ -25,8 +25,9 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.model.IModel;
 
 import org.apache.causeway.commons.internal.collections._Lists;
-import org.apache.causeway.core.metamodel.tabular.interactive.DataRow;
 import org.apache.causeway.core.metamodel.tabular.interactive.DataTableInteractive;
+import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowToggleWkt;
+import org.apache.causeway.viewer.wicket.model.models.interaction.coll.DataRowWkt;
 import org.apache.causeway.viewer.wicket.ui.components.widgets.checkbox.ContainedToggleboxPanel;
 import org.apache.causeway.viewer.wicket.ui.util.Wkt;
 
@@ -45,7 +46,8 @@ extends GenericColumnAbstract {
         public boolean isSetAll() { return this == SET_ALL; }
     }
 
-    private IModel<DataTableInteractive> dataTableModelHolder;
+    private final IModel<DataTableInteractive> dataTableModelHolder;
+    private final List<ContainedToggleboxPanel> rowToggles = _Lists.newArrayList();
 
     public ToggleboxColumn(
             final IModel<DataTableInteractive> dataTableModelHolder) {
@@ -53,9 +55,13 @@ extends GenericColumnAbstract {
         this.dataTableModelHolder = dataTableModelHolder;
     }
 
+    public void removeToggles() {
+        rowToggles.clear();
+    }
+
     @Override
-    protected Component createCellComponent(
-            final String componentId, final DataRow dataRow, final IModel<Boolean> dataRowToggle) {
+    protected Component createCellComponent(final String componentId, final DataRowWkt dataRowWkt) {
+        var dataRowToggle = new DataRowToggleWkt(dataRowWkt);
         val rowToggle = new ContainedToggleboxPanel(componentId, dataRowToggle);
         rowToggles.add(rowToggle);
         return rowToggle.setOutputMarkupId(true);
@@ -66,22 +72,23 @@ extends GenericColumnAbstract {
         val bulkToggle = new ContainedToggleboxPanel(
                 componentId,
                 new BulkToggleWkt(dataTableModelHolder),
-                this::onBulkUpdate);
+                    this::onBulkUpdate);
         Wkt.cssAppend(bulkToggle, "togglebox-column");
         return bulkToggle;
     }
 
     private void onBulkUpdate(final Boolean isChecked, final AjaxRequestTarget target) {
-        val bulkToggle = BulkToggle.valueOf(isChecked);
-        for (ContainedToggleboxPanel rowToggle : rowToggles) {
-            rowToggle.set(bulkToggle, target);
-        }
-    }
+        var dataTableInteractive = dataTableModelHolder.getObject();
 
-    private final List<ContainedToggleboxPanel> rowToggles = _Lists.newArrayList();
+        //TODO[CAUSEWAY-3772] don't trample over table model
+        dataTableInteractive.whileToggleAllDo(()->{
+            val bulkToggle = BulkToggle.valueOf(isChecked);
+            for (ContainedToggleboxPanel rowToggle : rowToggles) {
+                rowToggle.set(bulkToggle, target);
+            }
+        });
+        dataTableInteractive.notifySelectionChangeListeners();
 
-    public void removeToggles() {
-        rowToggles.clear();
     }
 
 }

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/icons/CollectionContentsAsIconsPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/icons/CollectionContentsAsIconsPanel.java
@@ -48,7 +48,7 @@ extends PanelAbstract<DataTableInteractive, EntityCollectionModel> {
     private void buildGui() {
         final EntityCollectionModel model = getModel();
 
-        val visibleAdapters = model.getDataTableModel().getDataRowsFiltered()
+        val visibleAdapters = model.getDataTableModel().getDataRowsFilteredAndSorted()
                 .getValue()
                 .map(DataRow::getRowElement)
                 .toList();

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/summary/CollectionContentsAsSummary.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/collectioncontents/summary/CollectionContentsAsSummary.java
@@ -104,7 +104,7 @@ implements CollectionCountProvider {
             val propertyColumnName = numberAssociation.getCanonicalFriendlyName();
             Wkt.labelAdd(item, ID_PROPERTY_NAME, propertyColumnName);
 
-            val visibleAdapters = model.getDataTableModel().getDataRowsFiltered()
+            val visibleAdapters = model.getDataTableModel().getDataRowsFilteredAndSorted()
                     .getValue()
                     .map(DataRow::getRowElement)
                     .toList();

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/checkbox/ContainedToggleboxPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/checkbox/ContainedToggleboxPanel.java
@@ -58,7 +58,11 @@ extends PanelAbstract<Boolean, Model<Boolean>> {
         val markupContainer = Wkt.containerAdd(this, ID_CONTAINER);
         val form = Wkt.formAdd(markupContainer, ID_FORM);
         this.checkbox = Wkt.checkboxAdd(
-                form, ID_TOGGLEBOX, model, ajaxTarget->onUpdate.accept(model.getObject(), ajaxTarget));
+                form, ID_TOGGLEBOX, model, ajaxTarget->{
+                    //TODO[CAUSEWAY-3772] debug WKT checkbox
+                    System.err.printf("ContainedToggleboxPanel update %s%n", model.getObject());
+                    onUpdate.accept(model.getObject(), ajaxTarget);
+                });
     }
 
     public void set(

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/checkbox/ContainedToggleboxPanel.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/components/widgets/checkbox/ContainedToggleboxPanel.java
@@ -58,11 +58,8 @@ extends PanelAbstract<Boolean, Model<Boolean>> {
         val markupContainer = Wkt.containerAdd(this, ID_CONTAINER);
         val form = Wkt.formAdd(markupContainer, ID_FORM);
         this.checkbox = Wkt.checkboxAdd(
-                form, ID_TOGGLEBOX, model, ajaxTarget->{
-                    //TODO[CAUSEWAY-3772] debug WKT checkbox
-                    System.err.printf("ContainedToggleboxPanel update %s%n", model.getObject());
-                    onUpdate.accept(model.getObject(), ajaxTarget);
-                });
+                form, ID_TOGGLEBOX, model, ajaxTarget->
+                    onUpdate.accept(model.getObject(), ajaxTarget));
     }
 
     public void set(

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/pages/common/bootstrap/css/bootstrap-overrides-all-v2.css
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/pages/common/bootstrap/css/bootstrap-overrides-all-v2.css
@@ -681,6 +681,13 @@ ul.dropdown-menu {
     padding-top: 0px;
 }
 
+/* table search bar is present only optionally on tables, so if present, 
+	it needs a bit of top spacing (but only in parented tables, 
+	standalone tables don't have the 'padding-top: 0px' CSS hack) */
+.collection.card-body .table-search-bar{
+    padding-top: calc(.5 * var(--bs-card-spacer-y));
+}
+
 .collectionPanel .card.card-body {
     background-color: transparent;
     margin-bottom: 0px;

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/panels/FormExecutorDefault.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/panels/FormExecutorDefault.java
@@ -161,7 +161,7 @@ implements FormExecutor, HasCommonContext {
             //XXX triggers ManagedObject.getBookmarkRefreshed()
             val resultResponse = actionOrPropertyModel.fold(
                     act->ActionResultResponseType
-                            .determineAndInterpretResult(act, ajaxTarget, resultAdapter, act.snapshotArgs()),
+                            .determineAndInterpretResult(act, ajaxTarget, resultAdapter),
                     prop->ActionResultResponseType
                             .toEntityPage(resultAdapter));
 

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
@@ -471,7 +471,6 @@ public class Wkt {
         return new AjaxCheckBox(id, checkedModel) {
             private static final long serialVersionUID = 1L;
             @Override protected void onUpdate(final AjaxRequestTarget target) {
-                System.err.printf("AjaxCheckBox onUpdate %s%n", id); //TODO[CAUSEWAY-3772] debug AjaxCheckBox
                 onUpdate.accept(target);
             }
             /**

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
@@ -471,7 +471,7 @@ public class Wkt {
         return new AjaxCheckBox(id, checkedModel) {
             private static final long serialVersionUID = 1L;
             @Override protected void onUpdate(final AjaxRequestTarget target) {
-                System.err.printf("AjaxCheckBox onUpdate %s%n", id); //TODO[CAUSEWAY-3772] debug
+                System.err.printf("AjaxCheckBox onUpdate %s%n", id); //TODO[CAUSEWAY-3772] debug AjaxCheckBox
                 onUpdate.accept(target);
             }
             /**

--- a/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
+++ b/viewers/wicket/ui/src/main/java/org/apache/causeway/viewer/wicket/ui/util/Wkt.java
@@ -471,7 +471,9 @@ public class Wkt {
         return new AjaxCheckBox(id, checkedModel) {
             private static final long serialVersionUID = 1L;
             @Override protected void onUpdate(final AjaxRequestTarget target) {
-                onUpdate.accept(target); }
+                System.err.printf("AjaxCheckBox onUpdate %s%n", id); //TODO[CAUSEWAY-3772] debug
+                onUpdate.accept(target);
+            }
             /**
              * [CAUSEWAY-3005] Any action dialog submission on the same page will
              * result in a new {@link DataTableInteractive}, where any previously rendered check-boxes


### PR DESCRIPTION
- [x] table search support for backend (polish SPI)
- [x] add table-search support
- [x] let Search SPI provide the search placeholder (rendering)
- [x] preserve selected table rows when sorting or searching (keep UI and model in sync)
- [x] rework table memento to capture elements selected as some equivalent of list of `int`
- [x] UI running out of sync with table model
- [x] associated action, does not get the selected data rows (problem with using outdated table model when starting new param neg.)
- [x] fix recreate from memento results in handleRowSelect calls
- [x] cleanup debug stuff