### PR TITLE
CAUSEWAY-3840. Remove invalid repository.apache.org definition

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -2248,13 +2248,6 @@ It is therefore a copy of org.apache:apache, with customisations clearly identif
 			</snapshots>
 		</repository>
 		<repository>
-			<id>Apache Repository</id>
-			<url>https://repository.apache.org/</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
 			<!-- required for RestEasy -->
 			<id>JBoss Public Release</id>
 			<url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove definition of `repository.apache.org` pointing to invalid URL.

1. Build [tries to download](https://github.com/apache/causeway/actions/runs/12346213801/job/34451461654#step:9:13083) non-Apache artifacts from Apache repo:

```
[INFO] Downloading from Apache Repository: https://repository.apache.org/org/assertj/assertj-bom/3.25.3/assertj-bom-3.25.3.pom
```

2. URL is wrong, [does not even work](https://github.com/apache/causeway/actions/runs/12346213801/job/34451461654#step:9:13051) for Apache artifacts:

```
[INFO] Downloading from Apache Repository: https://repository.apache.org/org/apache/activemq/activemq-bom/6.1.3/activemq-bom-6.1.3.pom
```

```
curl --head https://repository.apache.org/org/apache/activemq/activemq-bom/6.1.3/activemq-bom-6.1.3.pom
HTTP/1.1 404 Not Found
```

> `repository.apache.org` should only be used for the testing of pre-production ASF code artifacts. Maven Central is the correct public java artifact repository service. ([source](https://infra.apache.org/infra-ban.html))

https://issues.apache.org/jira/browse/CAUSEWAY-3840

## How was this patch tested?

Unfortunately could not test it, because build from scratch fails even on `master`:

```
$ mvn -B -DskipTests clean verify
...
[INFO] --- remote-resources:3.2.0:process (process-resource-bundles) @ causeway-bom ---
[INFO] Preparing remote bundle org.apache.causeway:supplemental-model:1.0
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/causeway/supplemental-model/1.0/supplemental-model-1.0.jar
[INFO] Downloading from Apache Repository: https://repository.apache.org/org/apache/causeway/supplemental-model/1.0/supplemental-model-1.0.jar
[INFO] Downloading from JBoss Public Release: https://repository.jboss.org/nexus/content/groups/public-jboss/org/apache/causeway/supplemental-model/1.0/supplemental-model-1.0.jar
[INFO] Downloading from sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots/org/apache/causeway/supplemental-model/1.0/supplemental-model-1.0.jar
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:3.2.0:process (process-resource-bundles) on project causeway-bom: Error processing remote resources: The following artifacts could not be resolved: org.apache.causeway:supplemental-model:jar:1.0 (absent): Could not find artifact org.apache.causeway:supplemental-model:jar:1.0 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```