### PR TITLE
CAUSEWAY-3856: Fix link in CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,3 +1,3 @@
 = Contributing
 
-You can find full details of how to contribute back to Causeway at our https://causeway.apache.org/conguide/2.0.0-M8/contributing.html[main website].
+You can find full details of how to contribute back to Causeway at our https://causeway.apache.org/conguide/latest/about.html[main website].


### PR DESCRIPTION
Currently link on CONTRIBUTING.adoc routes to 404 due to milestone version in the path i.e. `2.0.0-M8`
![image](https://github.com/user-attachments/assets/b92bcd41-8014-48dc-88f6-75173e4cd385)

This change fixes the path to use `latest` .

