### PR TITLE
markdown persistence dependency for Wicket renamed

### DIFF
--- a/valuetypes/markdown/adoc/modules/markdown/pages/about.adoc
+++ b/valuetypes/markdown/adoc/modules/markdown/pages/about.adoc
@@ -85,7 +85,7 @@ In addition, in the webapp module of your application, add the following depende
 ----
 <dependency>
     <groupId>org.apache.causeway.valuetypes</groupId>
-    <artifactId>causeway-valuetypes-markdown-xxx</artifactId>   <!--.-->
+    <artifactId>causeway-valuetypes-markdown-persistence-xxx</artifactId>   <!--.-->
 </dependency>
 ----
 <.> where `xxx` is `jpa` (if using xref:pjpa::about.adoc[]) or `jdo` (if using xref:pjdo::about.adoc[]).


### PR DESCRIPTION
This is the dependency name that works in 3.2.0