### PR TITLE
Allows Action Semantics of SAFE_AND_REQUEST_CACHEABLE

### DIFF
--- a/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/execution/ActionExecutor.java
+++ b/core/metamodel/src/main/java/org/apache/causeway/core/metamodel/execution/ActionExecutor.java
@@ -220,7 +220,7 @@ implements
         final boolean cacheable = semanticsFacet != null && semanticsFacet.value().isSafeAndRequestCacheable();
         if(cacheable) {
             final QueryResultsCache queryResultsCache = getQueryResultsCache();
-            final Object[] targetPojoPlusExecutionParameters = _Arrays.combine(executionParameters, targetPojo);
+            final Object[] targetPojoPlusExecutionParameters = _Arrays.combineWithExplicitType(Object.class, executionParameters, targetPojo);
             return queryResultsCache.execute(
                     ()->CanonicalInvoker.invoke(method, targetPojo, executionParameters),
                     targetPojo.getClass(), method.getName(), targetPojoPlusExecutionParameters);


### PR DESCRIPTION
I tested this with a one-off `causeway-app-simpleapp` `jpa` branch set to `3.0.0-SNAPHOT` and having the rename action be `SAFE_AND_REQUEST_CACHEABLE` with two parameters. The extra parameter might be incidental as I was focused on verifying the test failed.  It failed the integTest until I added this fix to the `main` branch.