### PR TITLE
CAUSEWAY-3887 Metamodel and not Persistence import is required.

### DIFF
--- a/valuetypes/markdown/adoc/modules/markdown/pages/about.adoc
+++ b/valuetypes/markdown/adoc/modules/markdown/pages/about.adoc
@@ -98,7 +98,8 @@ And in your application's xref:userguide::modules.adoc#appmanifest[App Manifest]
 @Configuration
 @Import({
         CausewayModuleValMarkdownUiWkt.class,
-        CausewayModuleValMarkdownPersistenceXxx.class,  <!--.-->
+		CausewayModuleValMarkdownMetaModel.class,
+        
         ...
 })
 public class AppManifest {


### PR DESCRIPTION
In my testing, I found that the metamodel import is required and the persistence one has no effect.  My fork referenced in the ticket has the working SimpleApp V3-JPA with a Markdown property.