### PR TITLE
Fix String format locales to pass unit tests with non-US decimal format.

### DIFF
--- a/commons/src/test/java/org/apache/causeway/commons/collections/CanCompareTest.java
+++ b/commons/src/test/java/org/apache/causeway/commons/collections/CanCompareTest.java
@@ -20,6 +20,8 @@ package org.apache.causeway.commons.collections;
 
 import java.util.List;
 
+import java.util.Locale;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -70,7 +72,7 @@ class CanCompareTest {
                         c = -1;
                     }
                     assertEquals(expectationMatrix[row][col], c,
-                            String.format("failed in (row, col) (%d, %d) with (%s, %s)",
+                            String.format(Locale.US, "failed in (row, col) (%d, %d) with (%s, %s)",
                                     row, col, left, right));
                 }
                 ++col;

--- a/commons/src/test/java/org/apache/causeway/commons/collections/CanTest.java
+++ b/commons/src/test/java/org/apache/causeway/commons/collections/CanTest.java
@@ -20,6 +20,7 @@ package org.apache.causeway.commons.collections;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -423,7 +424,7 @@ class CanTest {
         // simulates a zip-function with nullable result
         @Nullable static String format(final Customer customer, final int ordinal) {
             return StringUtils.hasLength(customer.name)
-                    ? String.format("%d->%s", ordinal, customer.name)
+                    ? String.format(Locale.US, "%d->%s", ordinal, customer.name)
                     : null;
         }
     }

--- a/commons/src/test/java/org/apache/causeway/commons/graph/GraphUtilsTest.java
+++ b/commons/src/test/java/org/apache/causeway/commons/graph/GraphUtilsTest.java
@@ -18,7 +18,10 @@
  */
 package org.apache.causeway.commons.graph;
 
+import java.text.NumberFormat;
 import java.util.Comparator;
+
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -133,7 +136,7 @@ class GraphUtilsTest {
         var graph = gBuilder.build();
         var textForm = graph.toString(
                 NodeFormatter.of(Customer::name),
-                edgeAttr->String.format("(weight=%.1f)", (double)edgeAttr));
+                edgeAttr->String.format(Locale.US, "(weight=%.1f)", (double)edgeAttr));
         //debug
         //System.err.println(textForm);
 
@@ -161,7 +164,7 @@ class GraphUtilsTest {
                 .sorted(Comparator.comparing(Customer::name)); // test sorting
         var textForm = graph.toString(
                 NodeFormatter.of(Customer::name),
-                edgeAttr->String.format("(weight=%.1f)", (double)edgeAttr));
+                edgeAttr->String.format(Locale.US, "(weight=%.1f)", (double)edgeAttr));
         //debug
         //System.err.println(textForm);
 
@@ -241,7 +244,7 @@ class GraphUtilsTest {
 
         var textForm = graph.toString(
                 NodeFormatter.of(Customer::name),
-                edgeAttr->String.format("(weight=%.1f)", (double)edgeAttr));
+                edgeAttr->String.format(Locale.US, "(weight=%.1f)", (double)edgeAttr));
         //debug
         //System.err.println(textForm);
 


### PR DESCRIPTION
Without this fix, using my non-US dafault locale I get:

```
/Users/john/Library/Java/JavaVirtualMachines/temurin-21.0.6/Contents/Home/bin/java -javaagent:/Users/john/Library/Caches/JetBrains/IntelliJIdea2025.1/captureAgent/debugger-agent.jar=file:///var/folders/57/2h75krjx6sx3h__x3l724l7m0000gp/T/capture16416934520741886359.props -ea -DisRunningWithSurefire=true -Xmx384m -XX:+EnableDynamicAgentLoading -Didea.test.cyclic.buffer.size=20478976 -javaagent:/Users/john/Applications/IntelliJ IDEA Ultimate.app/Contents/lib/idea_rt.jar=54880 -Dkotlinx.coroutines.debug.enable.creation.stack.trace=false -Ddebugger.agent.enable.coroutines=true -Dkotlinx.coroutines.debug.enable.flows.stack.trace=true -Dkotlinx.coroutines.debug.enable.mutable.state.flows.stack.trace=true --patch-module org.apache.causeway.commons=/Users/john/work/ambition/causeway/commons/target/test-classes --add-reads org.apache.causeway.commons=ALL-UNNAMED --add-opens org.apache.causeway.commons/org.apache.causeway.commons.graph=ALL-UNNAMED --add-modules org.apache.causeway.commons -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 -classpath /Users/john/.m2/repository/org/junit/platform/junit-platform-launcher/1.13.1/junit-platform-launcher-1.13.1.jar:/Users/john/Applications/IntelliJ IDEA Ultimate.app/Contents/lib/idea_rt.jar:/Users/john/Applications/IntelliJ IDEA Ultimate.app/Contents/plugins/junit/lib/junit5-rt.jar:/Users/john/Applications/IntelliJ IDEA Ultimate.app/Contents/plugins/junit/lib/junit-rt.jar:/Users/john/work/ambition/causeway/commons/target/test-classes:/Users/john/.m2/repository/com/fasterxml/woodstox/woodstox-core/7.1.1/woodstox-core-7.1.1.jar:/Users/john/.m2/repository/org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar:/Users/john/.m2/repository/jakarta/enterprise/jakarta.enterprise.cdi-api/4.1.0/jakarta.enterprise.cdi-api-4.1.0.jar:/Users/john/.m2/repository/jakarta/enterprise/jakarta.enterprise.lang-model/4.1.0/jakarta.enterprise.lang-model-4.1.0.jar:/Users/john/.m2/repository/jakarta/interceptor/jakarta.interceptor-api/2.2.0/jakarta.interceptor-api-2.2.0.jar:/Users/john/.m2/repository/jakarta/transaction/jakarta.transaction-api/2.0.1/jakarta.transaction-api-2.0.1.jar:/Users/john/.m2/repository/org/jboss/spec/javax/ws/rs/jboss-jaxrs-api_2.1_spec/2.0.2.Final/jboss-jaxrs-api_2.1_spec-2.0.2.Final.jar:/Users/john/.m2/repository/org/eclipse/angus/angus-activation/2.0.2/angus-activation-2.0.2.jar:/Users/john/.m2/repository/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-json-provider/2.19.0/jackson-jakarta-rs-json-provider-2.19.0.jar:/Users/john/.m2/repository/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-base/2.19.0/jackson-jakarta-rs-base-2.19.0.jar:/Users/john/.m2/repository/org/springframework/spring-aop/6.2.7/spring-aop-6.2.7.jar:/Users/john/.m2/repository/org/springframework/spring-jcl/6.2.7/spring-jcl-6.2.7.jar:/Users/john/.m2/repository/org/springframework/spring-expression/6.2.7/spring-expression-6.2.7.jar:/Users/john/.m2/repository/io/micrometer/micrometer-observation/1.15.0/micrometer-observation-1.15.0.jar:/Users/john/.m2/repository/io/micrometer/micrometer-commons/1.15.0/micrometer-commons-1.15.0.jar:/Users/john/.m2/repository/org/springframework/spring-tx/6.2.7/spring-tx-6.2.7.jar:/Users/john/.m2/repository/org/springframework/boot/spring-boot-starter/3.5.0/spring-boot-starter-3.5.0.jar:/Users/john/.m2/repository/org/springframework/boot/spring-boot/3.5.0/spring-boot-3.5.0.jar:/Users/john/.m2/repository/org/springframework/boot/spring-boot-autoconfigure/3.5.0/spring-boot-autoconfigure-3.5.0.jar:/Users/john/.m2/repository/org/springframework/boot/spring-boot-starter-log4j2/3.5.0/spring-boot-starter-log4j2-3.5.0.jar:/Users/john/.m2/repository/org/apache/logging/log4j/log4j-slf4j2-impl/2.24.3/log4j-slf4j2-impl-2.24.3.jar:/Users/john/.m2/repository/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3.jar:/Users/john/.m2/repository/org/apache/logging/log4j/log4j-jul/2.24.3/log4j-jul-2.24.3.jar:/Users/john/.m2/repository/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar:/Users/john/.m2/repository/org/junit/jupiter/junit-jupiter-api/5.13.1/junit-jupiter-api-5.13.1.jar:/Users/john/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/Users/john/.m2/repository/org/junit/platform/junit-platform-commons/1.13.1/junit-platform-commons-1.13.1.jar:/Users/john/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/Users/john/.m2/repository/org/junit/jupiter/junit-jupiter-engine/5.13.1/junit-jupiter-engine-5.13.1.jar:/Users/john/.m2/repository/org/junit/platform/junit-platform-engine/1.13.1/junit-platform-engine-1.13.1.jar:/Users/john/.m2/repository/org/junit/jupiter/junit-jupiter-params/5.13.1/junit-jupiter-params-5.13.1.jar:/Users/john/.m2/repository/org/hamcrest/hamcrest-library/3.0/hamcrest-library-3.0.jar:/Users/john/.m2/repository/org/hamcrest/hamcrest-core/3.0/hamcrest-core-3.0.jar:/Users/john/.m2/repository/org/hamcrest/hamcrest/3.0/hamcrest-3.0.jar:/Users/john/.m2/repository/com/approvaltests/approvaltests/24.22.0/approvaltests-24.22.0.jar:/Users/john/.m2/repository/com/approvaltests/approvaltests-util/24.22.0/approvaltests-util-24.22.0.jar:/Users/john/.m2/repository/org/apache/commons/commons-lang3/3.17.0/commons-lang3-3.17.0.jar:/Users/john/.m2/repository/com/google/code/gson/gson/2.13.1/gson-2.13.1.jar:/Users/john/.m2/repository/com/google/errorprone/error_prone_annotations/2.38.0/error_prone_annotations-2.38.0.jar -p /Users/john/work/ambition/causeway/commons/target/classes:/Users/john/.m2/repository/org/projectlombok/lombok/1.18.38/lombok-1.18.38.jar:/Users/john/.m2/repository/jakarta/activation/jakarta.activation-api/2.1.3/jakarta.activation-api-2.1.3.jar:/Users/john/.m2/repository/org/springframework/spring-core/6.2.7/spring-core-6.2.7.jar:/Users/john/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar:/Users/john/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar:/Users/john/.m2/repository/org/jsoup/jsoup/1.20.1/jsoup-1.20.1.jar:/Users/john/.m2/repository/org/springframework/spring-beans/6.2.7/spring-beans-6.2.7.jar:/Users/john/.m2/repository/com/sun/xml/bind/jaxb-impl/4.0.5/jaxb-impl-4.0.5.jar:/Users/john/.m2/repository/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar:/Users/john/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar:/Users/john/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar:/Users/john/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.19.0/jackson-datatype-jsr310-2.19.0.jar:/Users/john/.m2/repository/jakarta/xml/bind/jakarta.xml.bind-api/4.0.2/jakarta.xml.bind-api-4.0.2.jar:/Users/john/.m2/repository/org/apache/logging/log4j/log4j-api/2.24.3/log4j-api-2.24.3.jar:/Users/john/.m2/repository/org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar:/Users/john/.m2/repository/com/sun/xml/bind/jaxb-core/4.0.5/jaxb-core-4.0.5.jar:/Users/john/.m2/repository/jakarta/inject/jakarta.inject-api/2.0.1.MR/jakarta.inject-api-2.0.1.MR.jar:/Users/john/.m2/repository/org/springframework/spring-context/6.2.7/spring-context-6.2.7.jar:/Users/john/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar:/Users/john/.m2/repository/com/fasterxml/jackson/module/jackson-module-jakarta-xmlbind-annotations/2.19.0/jackson-module-jakarta-xmlbind-annotations-2.19.0.jar:/Users/john/.m2/repository/jakarta/annotation/jakarta.annotation-api/2.1.1/jakarta.annotation-api-2.1.1.jar:/Users/john/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.19.0/jackson-datatype-jdk8-2.19.0.jar com.intellij.rt.junit.JUnitStarter -ideVersion5 -junit5 org.apache.causeway.commons.graph.GraphUtilsTest,filterUndirectedGraph

org.opentest4j.AssertionFailedError: expected line #1 doesn't match actual line #1
	expected: `A - B (weight=0.1)`
	  actual: `A - B (weight=0,1)`
<Click to see difference>


	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertLinesMatch$LinesMatcher.fail(AssertLinesMatch.java:203)
	at org.junit.jupiter.api.AssertLinesMatch$LinesMatcher.assertLinesMatchWithFastForward(AssertLinesMatch.java:178)
	at org.junit.jupiter.api.AssertLinesMatch$LinesMatcher.assertLinesMatch(AssertLinesMatch.java:112)
	at org.junit.jupiter.api.AssertLinesMatch.assertLinesMatch(AssertLinesMatch.java:80)
	at org.junit.jupiter.api.AssertLinesMatch.assertLinesMatch(AssertLinesMatch.java:42)
	at org.junit.jupiter.api.Assertions.assertLinesMatch(Assertions.java:1603)
	at org.apache.causeway.commons/org.apache.causeway.commons.graph.GraphUtilsTest.filterUndirectedGraph(GraphUtilsTest.java:251)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)


Process finished with exit code 255

```